### PR TITLE
feat: added coc and cg

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
+reported to the community leaders responsible for enforcement at ihr-admin@iij-ii.co.jp
 .
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to Internet Health Report
+
+First off, thanks for taking the time to contribute! 🎉🎉
+
+When contributing to this repository, please first discuss the change you wish to make via issue with the maintainers of this repository before making a change. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [IHR Code of Conduct](), please follow it in all your interaction with the project. By participating, you are expected to uphold this code. Please report unacceptable behavior to ihr-admin@iij-ii.co.jp
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a
+   build. Add only relevant files to commit and ignore the rest to keep the repo clean.
+2. Update the README.md with details of changes to the interface, this includes new environment
+   variables, exposed ports, useful file locations and container parameters.
+3. You should request review from the maintainers once you submit the Pull Request.
+
+## Instructions
+
+- Git Workflow
+
+```bash
+## Step 1: Fork Repository
+
+## Step 2: Git Set Up & Download
+# Clone the repo
+$ git clone https://github.com/<User-Name>/<Repo-Name>.git
+# Add upstream remote
+$ git remote add upstream https://github.com/InternetHealthReport/ihr-website.git
+# Fetch and merge with upstream/master
+$ git fetch upstream
+$ git merge upstream/master
+
+## Step 2: Create and Publish Working Branch
+$ git checkout -b <type>/<issue|issue-number>/{<additional-fixes>}
+$ git push origin <type>/<issue|issue-number>/{<additional-fixes>}
+
+## Types:
+# wip - Work in Progress; long term work; mainstream changes;
+# feat - New Feature; future planned; non-mainstream changes;
+# bug - Bug Fixes
+# exp - Experimental; random experiemntal features;
+```
+
+- On Task Completion:
+
+```bash
+## Committing and pushing your work
+# Ensure branch
+$ git branch
+# Fetch and merge with upstream/master
+$ git fetch upstream
+$ git merge upstream/master
+# Add untracked files
+$ git add .
+# Commit all changes with appropriate commit message and description
+$ git commit -m "your-commit-message" -m "your-commit-description"
+# Fetch and merge with upstream/master again
+$ git fetch upstream
+$ git merge upstream/master
+# Push changes to your forked repository
+$ git push origin <type>/<issue|issue-number>/{<additional-fixes>}
+
+## Creating the PR using GitHub Website
+# Create Pull Request from <type>/<issue|issue-number>/{<additional-fixes>} branch in your forked repository to the master branch in the upstream repository
+# After creating PR, add a Reviewer (Any Admin) and yourself as the assignee
+# Link Pull Request to appropriate Issue, or Project+Milestone (if no issue created)
+# IMPORTANT: Do Not Merge the PR unless specifically asked to by an admin.
+```
+
+- After PR Merge
+
+```bash
+# Delete branch from forked repo
+$ git branch -d <type>/<issue|issue-number>/{<additional-fixes>}
+$ git push --delete origin <type>/<issue|issue-number>/{<additional-fixes>}
+# Fetch and merge with upstream/master
+$ git checkout master
+$ git pull upstream
+$ git push origin
+```
+
+- Always follow [commit message standards](https://chris.beams.io/posts/git-commit/)
+- About the [fork-and-branch workflow](https://blog.scottlowe.org/2015/01/27/using-fork-branch-git-workflow/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ $ git push origin <type>/<issue|issue-number>/{<additional-fixes>}
 # wip - Work in Progress; long term work; mainstream changes;
 # feat - New Feature; future planned; non-mainstream changes;
 # bug - Bug Fixes
-# exp - Experimental; random experiemntal features;
+# exp - Experimental; random experimental features;
 ```
 
 - On Task Completion:


### PR DESCRIPTION
I have added a Code of conduct along with Contributing guidelines to the project.  In my Contributing guideline, I have not provided a link for the IHR Code of conduct, in case this gets merged I would add the link else the link would redirect to my repo. Let me know what you think about the rules and approach I have provided. @romain-fontugne sir incase you need some changes let me know I would make and send the PR again.

closes #28 