### PR TITLE
fixed dropdown value population issue of COVID19 page

### DIFF
--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -53,7 +53,7 @@
             </h3>
           </div>
         </div>
-        <div v-for="asn in asns" :key="`${arn.name}-${asn.as}`">
+        <div v-for="asn in asns" :key="`${asn.name}-${asn.as}`">
           <div class="row">
             <div class="col-12 text-center q-pa-md">
               <div class="IHR_anchor" :id="asn.as"></div>


### PR DESCRIPTION
Resolves #76 
## Description

There was a typing mistake in the variable name used in the Component (Corona.vue) . Because of that, the dropdown field was not getting populated with the selected option and the child components were unable to render.
## Motivation and Context

After fixing the issue, all the child components that are dependent on the data are now working perfectly fine.


## How Has This Been Tested?
Manual testing.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
