### PR TITLE
fixed issue #124

### DIFF
--- a/src/locales/langs/en-us.json
+++ b/src/locales/langs/en-us.json
@@ -63,12 +63,12 @@
   "Networks": {
     "headerString": {
       "loading": "Loading in progress...",
-      "notFound": "you are searching is not available",
+      "notFound": "AS doesn't exists",
       "expired": "Request expired"
     },
     "subHeader": {
       "loading": "please wait",
-      "notFound": "the AS is not in our server",
+      "notFound": "The queried network",
       "expired": "the sever is under load, please try again later"
     }
   },

--- a/src/views/Networks.vue
+++ b/src/views/Networks.vue
@@ -268,7 +268,7 @@ export default {
             let filter = new NetworkQuery().asNumber(this.asNumber)
             this.$ihr_api.network(filter, results => {
                 if (results.count < 1) {
-                    //this.loadingStatus = LOADING_STATUS.ERROR;
+                    this.loadingStatus = LOADING_STATUS.NOT_FOUND;
                     return
                 }
                 // Hide tabs if not necessary


### PR DESCRIPTION
### Description
Whenever the user requests a report that does not exist it will show a default message.

### Motivation and Context
* Before users get the default message please wait - loading in progress... even when there is no report available.
* Now if a report does not exist on the server at least users will know that it does not exist.

It fixes the issue #124 

### How Has This Been Tested?
* It has been tested in the Local server.
* I made sure changes don't affect the other default messages.
* It has been tested with the following URLs.
1. http://localhost:8080/ihr/en-us/networks/AS2497
2. http://localhost:8080/ihr/en-us/networks/AS74598

### Screenshots
**Before**

![before](https://user-images.githubusercontent.com/73768090/168635058-dded2802-fe63-407f-8e0a-a32683287148.PNG)

**After**

![after](https://user-images.githubusercontent.com/73768090/168635145-4b5d3a43-c448-4149-8c88-6bc24c129f0e.PNG)

