### PR TITLE
bug/232/banner responsiveness for smaller screen

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -165,11 +165,14 @@ export default {
       background-image url('~@/assets/imgs/global-banner.png')
       background-repeat no-repeat
       background-position right top
-      background-size contain
+      background-size cover
       @media screen and (max-width: 600px)
         padding-left 1rem
         padding-right 1rem
-        max-height 350px
+        max-height 350px  
+      @media screen and (max-width: 768px) {
+        background-position center center
+      }
 
       &-button
         margin-top 40px


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Made banner image to cover the entire hero section

<!--- Describe your changes in detail -->

## Motivation and Context
The banner of the hero image was not covering the hero section on smaller screen
#232 

## How Has This Been Tested?
I tested it on various screen sizes

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/67755128/210939050-40db82cb-9b20-4862-bd53-87540997e0ca.png)
![image](https://user-images.githubusercontent.com/67755128/210939089-f53424a6-a4fd-46f9-82fc-d8c87ceaf219.png)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
