### PR TITLE
fix: documentation page made responsive

### DIFF
--- a/src/views/Documentation.vue
+++ b/src/views/Documentation.vue
@@ -234,20 +234,34 @@ export default {
 #IHR_
   &documentation-page
     margin 0pt auto
+    width 100%
     max-width 1200px
+    padding 0 1rem
 
 .IHR_
   &documentation-page
     & > h1
+      line-height 2rem
+      padding 0.5rem 0
+      font-weight 500
+      border-bottom 1px solid #ccc
+      margin 4rem 0 1.5rem
+      @media screen and (max-width: 720px)
+        font-size 22pt
+        margin 2rem 0 1rem
+
+    & > div
+      & > h2
+        margin-bottom 20pt
+        font-size 18pt
         line-height 1.5rem
-        padding 0.5rem 0
-        font-weight 500;
-        border-bottom 1px solid #ccc
-        margin 4rem 0 1.5rem
-
-    & > h2
-      margin-bottom 20pt
-
+        @media screen and (max-width: 600px)
+          font-size 16pt
+          margin-bottom 10pt
+      & > .text-body1
+        overflow-anchor none
+        & > a
+          overflow-anchor none
 
 .IHR_
   &documentation-page-sidebar
@@ -255,8 +269,10 @@ export default {
       margin-top 2pt
       width 88%
       margin 0px auto
-      font-size 15pt
+      font-size 16pt
       font-weight 500
+      @media screen and (max-width: 600px)
+        font-size 12pt
 
       &:first-letter
         text-transform capitalize
@@ -286,8 +302,12 @@ export default {
         padding-left 15px
 
 .IHR_anchor
-    display block
-    position relative
-    top -100px
-    visibility hidden
+  display block
+  position relative
+  top -100px
+  visibility hidden
+
+pre
+  overflow-x scroll
+
 </style>


### PR DESCRIPTION
Documentation page made responsive. Also better readability.

## Description

Changed CSS styles wherever necessary. Added media queries for responsiveness.

## Motivation and Context

Better readability and responsiveness
#260 

## How Has This Been Tested?

Tested on screens below 600px.

## Screenshots

![localhost_8080_ihr_startup_documentation(iPhone SE)](https://user-images.githubusercontent.com/70762571/219023240-182cc9a2-60d2-4d3c-b9a2-4330a58c9e8b.png)
ts (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
