### PR TITLE
Legend Hide issue solved

### DIFF
--- a/src/views/charts/AsInterdependenciesChart.vue
+++ b/src/views/charts/AsInterdependenciesChart.vue
@@ -311,7 +311,6 @@ export default {
 
       let anotherAsn
       let minX, maxX
-
       data.forEach(elem => {
         if (elem.asn == this.asNumber) return
         let trace = traces[elem.asn]
@@ -494,8 +493,14 @@ export default {
         }
       }
 
-      // console.log(this.traces)
-      // console.log(traces)
+      //console.log(this.traces.length)
+      //console.log(traces)
+
+      if(this.traces.length > 12){
+        this.layout.showlegend = false
+      }else{
+        this.layout.showlegend = true
+      }
     },
     fetchHegemonyCone(data) {
       console.log('fetchHegemonyCone')


### PR DESCRIPTION
## Description
Here I solved the issue #268 created by Romain Sir. It says for certain types of networks, such as those that exist in complex systems like computer networks or social networks, there may be a large number of dependencies between various components or nodes. These dependencies can be represented graphically using an AS (autonomous system) dependency graph, which shows the relationships between different ASes in a network.

However, when the number of dependencies in a network is very large, the legend of the AS dependency graph can completely obscure or hide the graph itself. This means that the information contained in the graph may be difficult or impossible to interpret, as the legend takes up too much space on the screen or page.


## Motivation and Context

1. Improved network performance: Understanding the dependencies between nodes in a network is crucial for optimizing network performance. If the AS dependency graph is obscured, it can be difficult or impossible to identify bottlenecks or diagnose problems, which can result in slower network speeds or even downtime.

2. Better decision making: When making decisions about a network, it is important to have a clear understanding of the dependencies between different components. If the AS dependency graph is obscured, it can be difficult to make informed decisions about how to allocate resources, upgrade hardware, or change configurations.

3. Enhanced network security: In today's world, cybersecurity is a major concern for many organizations. Understanding the dependencies between nodes in a network is critical for identifying potential vulnerabilities and securing the network against attacks. If the AS dependency graph is obscured, it can be difficult to identify these vulnerabilities and take appropriate measures to mitigate them.

4. Improved network scalability: As networks continue to grow in size and complexity, it is becoming increasingly important to develop new tools and techniques for visualizing and analyzing these systems. If the AS dependency graph is obscured, it can be difficult to scale the network effectively and efficiently.


## How Has This Been Tested?
To test the phenomenon of obscured legends in AS dependency graphs, you can refer to the video demonstration. The video shows that if the number of legends is less than 12, the graph works correctly, but if the number of legends exceeds 12, the graph becomes obscured. This is demonstrated in the video.
[IssueRelated.webm](https://user-images.githubusercontent.com/81790585/223102286-33b04329-2d6d-4268-88a2-61fdce53d746.webm)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
