### PR TITLE
Added logic to show relevant tables

### DIFF
--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -5,7 +5,8 @@
         <div class="text-h1">{{ title }}</div>
         <div class="text-h3">
           {{ interval.dayDiff() }}-day report ending on {{ reportDateFmt }}
-          <date-time-picker :min="minDate" :max="maxDate" :value="maxDate" @input="setReportDate" hideTime class="IHR_subtitle_calendar" />
+          <date-time-picker :min="minDate" :max="maxDate" :value="maxDate" @input="setReportDate" hideTime
+            class="IHR_subtitle_calendar" />
         </div>
         <!-- <button @click="generateReport()" class="np-btn">Generate Report</button> -->
       </div>
@@ -53,181 +54,275 @@
       </q-card-section>
       <q-separator />
     </q-card>
-    <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="hegemonyExpanded">
-      <template v-slot:header>
-        <div class="graph-header-div">
-          <q-item-section class="graph-header">
-            <q-item-section avatar>
-              <q-icon name="fas fa-project-diagram" color="primary" text-color="white" />
+    <div v-show="!this.nbAlarms['hegemony']">
+      <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="ndelayExpanded">
+        <template v-slot:header>
+          <div class="graph-header-div">
+            <q-item-section class="graph-header">
+              <q-item-section avatar>
+                <q-icon name="fas fa-project-diagram" color="primary" text-color="white" />
+              </q-item-section>
+
+              <q-item-section>
+                <a id=" hegemony"></a>
+                <div class="text-primary text-grey">
+                  {{ $t('charts.asInterdependencies.title') }}
+                </div>
+                <div class="text-caption text-grey">BGP data</div>
+              </q-item-section>
             </q-item-section>
 
-            <q-item-section>
-              <a id="hegemony"></a>
-              <div class="text-primary">
-                {{ $t('charts.asInterdependencies.title') }}
+            <q-item-section class="filter-div">
+              <div class="text" v-if="hegemonyExpanded">
+                <q-input debounce="300" v-model="hegemonyFilter" placeholder="Filter">
+                  <template v-slot:append>
+                    <q-icon name="fas fa-filter" />
+                  </template>
+                </q-input>
               </div>
-              <div class="text-caption text-grey">BGP data</div>
             </q-item-section>
-          </q-item-section>
+          </div>
+        </template>
+      </q-expansion-item>
+    </div>
+    <div v-show="this.nbAlarms['hegemony']">
+      <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="hegemonyExpanded">
+        <template v-slot:header>
+          <div class="graph-header-div">
+            <q-item-section class="graph-header">
+              <q-item-section avatar>
+                <q-icon name="fas fa-project-diagram" color="primary" text-color="white" />
+              </q-item-section>
 
-          <q-item-section class="filter-div">
-            <div class="text" v-if="hegemonyExpanded">
-              <q-input debounce="300" v-model="hegemonyFilter" placeholder="Filter">
-                <template v-slot:append>
-                  <q-icon name="fas fa-filter" />
-                </template>
-              </q-input>
-            </div>
-          </q-item-section>
-        </div>
-      </template>
-      <q-card class="IHR_charts-body">
-        <q-card-section>
-          <hegemony-alarms-chart
-            :start-time="startTime"
-            :end-time="endTime"
-            :fetch="fetch"
-            :min-deviation="minDeviationNetworkDelay"
-            :filter="hegemonyFilter"
-            @filteredRows="newFilteredRows('hegemony', $event)"
-            @loading="hegemonyLoading"
-            ref="ihrChartHegemonyAlarms"
-          />
-        </q-card-section>
-      </q-card>
-    </q-expansion-item>
-    <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="ndelayExpanded">
-      <template v-slot:header>
-        <div class="graph-header-div">
-          <q-item-section class="graph-header">
-            <q-item-section avatar>
-              <q-icon name="fas fa-shipping-fast" color="primary" text-color="white" />
+              <q-item-section>
+                <a id=" hegemony"></a>
+                <div class="text-primary">
+                  {{ $t('charts.asInterdependencies.title') }}
+                </div>
+                <div class="text-caption text-grey">BGP data</div>
+              </q-item-section>
             </q-item-section>
 
-            <q-item-section>
-              <a id="networkDelay"></a>
-              <div class="text-primary">{{ $t('charts.networkDelay.title') }}</div>
-              <div class="text-caption text-grey">Traceroute data</div>
-            </q-item-section>
-          </q-item-section>
-          <q-item-section class="filter-div">
-            <div class="text" v-if="ndelayExpanded">
-              <q-input debounce="300" v-model="ndelayFilter" placeholder="Filter">
-                <template v-slot:append>
-                  <q-icon name="fas fa-filter" />
-                </template>
-              </q-input>
-            </div>
-          </q-item-section>
-        </div>
-      </template>
-      <q-card class="IHR_charts-body">
-        <q-card-section>
-          <network-delay-alarms-chart
-            :start-time="startTime"
-            :end-time="endTime"
-            :fetch="fetch"
-            :min-deviation="minDeviationNetworkDelay"
-            :filter="ndelayFilter"
-            @filteredRows="newFilteredRows('networkDelay', $event)"
-            @loading="networkDelayLoading"
-            ref="ihrChartNetworkDelay"
-          />
-        </q-card-section>
-      </q-card>
-    </q-expansion-item>
-    <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="linkExpanded">
-      <template v-slot:header>
-        <div class="graph-header-div">
-          <q-item-section class="graph-header">
-            <q-item-section avatar>
-              <q-icon name="fas fa-exchange-alt" color="primary" text-color="white" />
-            </q-item-section>
-
-            <q-item-section>
-              <a id="linkDelay"></a>
-              <div class="text-primary">
-                {{ $t('charts.delayAndForwarding.title') }}
+            <q-item-section class="filter-div">
+              <div class="text" v-if="hegemonyExpanded">
+                <q-input debounce="300" v-model="hegemonyFilter" placeholder="Filter">
+                  <template v-slot:append>
+                    <q-icon name="fas fa-filter" />
+                  </template>
+                </q-input>
               </div>
-              <div class="text-caption text-grey">Traceroute data</div>
             </q-item-section>
-          </q-item-section>
-          <q-item-section class="filter-div">
-            <div class="text" v-if="linkExpanded">
-              <q-input debounce="300" v-model="linkFilter" placeholder="Filter">
-                <template v-slot:append>
-                  <q-icon name="fas fa-filter" />
-                </template>
-              </q-input>
-            </div>
-          </q-item-section>
-        </div>
-      </template>
-      <q-card class="IHR_charts-body">
-        <q-card-section>
-          <delay-chart
-            :start-time="startTime"
-            :end-time="endTime"
-            :fetch="fetch"
-            :min-nprobes="minNprobes"
-            :min-deviation="minDeviation"
-            :min-diffmedian="minDiffmedian"
-            :max-diffmedian="maxDiffmedian"
-            :filter="linkFilter"
-            @filteredRows="newFilteredRows('linkDelay', $event)"
-            @loading="linkDelayLoading"
-            :selected-asn="asnList"
-            ref="ihrChartDelay"
-            @prefix-details="showDetails($event)"
-          />
-        </q-card-section>
-      </q-card>
-    </q-expansion-item>
-    <q-expansion-item caption="RIPE Atlas log" header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="discoExpanded">
-      <template v-slot:header>
-        <div class="graph-header-div">
-          <q-item-section class="graph-header">
-            <q-item-section avatar>
-              <q-icon name="fas fa-plug" color="primary" text-color="white" />
+          </div>
+        </template>
+        <q-card class="IHR_charts-body">
+          <q-card-section>
+            <hegemony-alarms-chart :start-time="startTime" :end-time="endTime" :fetch="fetch"
+              :min-deviation="minDeviationNetworkDelay" :filter="hegemonyFilter"
+              @filteredRows="newFilteredRows('hegemony', $event)" @loading="hegemonyLoading"
+              ref="ihrChartHegemonyAlarms" />
+          </q-card-section>
+        </q-card>
+      </q-expansion-item>
+    </div>
+    <div v-show="!this.nbAlarms['networkDelay']">
+      <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="ndelayExpanded">
+        <template v-slot:header>
+          <div class="graph-header-div">
+            <q-item-section class="graph-header">
+              <q-item-section avatar>
+                <q-icon name="fas fa-shipping-fast" color="primary" text-color="white" />
+              </q-item-section>
+              <q-item-section>
+                <a id="networkDelay"></a>
+                <div class="text-primary text-grey">{{ $t('charts.networkDelay.title') }}</div>
+                <div class="text-caption text-grey">Traceroute data</div>
+              </q-item-section>
             </q-item-section>
-
-            <q-item-section>
-              <a id="disco"></a>
-              <div class="text-primary">
-                {{ $t('charts.disconnections.title') }}
+            <q-item-section class="filter-div">
+              <div class="text" v-if="ndelayExpanded">
+                <q-input debounce="300" v-model="ndelayFilter" placeholder="Filter">
+                  <template v-slot:append>
+                    <q-icon name="fas fa-filter" />
+                  </template>
+                </q-input>
               </div>
-              <div class="text-caption text-grey">RIPE Atlas log</div>
             </q-item-section>
-          </q-item-section>
-          <q-item-section class="filter-div">
-            <div class="text" v-if="discoExpanded">
-              <q-input debounce="300" v-model="discoFilter" placeholder="Filter">
-                <template v-slot:append>
-                  <q-icon name="fas fa-filter" />
-                </template>
-              </q-input>
-            </div>
-          </q-item-section>
-        </div>
-      </template>
+          </div>
+        </template>
+      </q-expansion-item>
+    </div>
+    <div v-show="this.nbAlarms['networkDelay']">
+      <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="ndelayExpanded">
+        <template v-slot:header>
+          <div class="graph-header-div">
+            <q-item-section class="graph-header">
+              <q-item-section avatar>
+                <q-icon name="fas fa-shipping-fast" color="primary" text-color="white" />
+              </q-item-section>
+              <q-item-section>
+                <a id="networkDelay"></a>
+                <div class="text-primary">{{ $t('charts.networkDelay.title') }}</div>
+                <div class="text-caption text-grey">Traceroute data</div>
+              </q-item-section>
+            </q-item-section>
+            <q-item-section class="filter-div">
+              <div class="text" v-if="ndelayExpanded">
+                <q-input debounce="300" v-model="ndelayFilter" placeholder="Filter">
+                  <template v-slot:append>
+                    <q-icon name="fas fa-filter" />
+                  </template>
+                </q-input>
+              </div>
+            </q-item-section>
+          </div>
+        </template>
+        <q-card class="IHR_charts-body">
+          <q-card-section>
+            <network-delay-alarms-chart :start-time="startTime" :end-time="endTime" :fetch="fetch"
+              :min-deviation="minDeviationNetworkDelay" :filter="ndelayFilter"
+              @filteredRows="newFilteredRows('networkDelay', $event)" @loading="networkDelayLoading"
+              ref="ihrChartNetworkDelay" />
+          </q-card-section>
+        </q-card>
+      </q-expansion-item>
+    </div>
+    <div v-show="!this.nbAlarms['linkDelay']">
+      <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="ndelayExpanded">
+        <template v-slot:header>
+          <div class="graph-header-div">
+            <q-item-section class="graph-header">
+              <q-item-section avatar>
+                <q-icon name="fas fa-exchange-alt" color="primary" text-color="white" />
+              </q-item-section>
 
-      <q-card class="IHR_charts-body">
-        <q-card-section>
-          <disco-chart
-            :start-time="startTime"
-            :end-time="endTime"
-            :fetch="fetch"
-            :min-avg-level="minAvgLevel"
-            :geoprobes.sync="geoProbes"
-            :filter="discoFilter"
-            @filteredRows="newFilteredRows('disco', $event)"
-            @loading="discoLoading"
-            :selected-asn="asnList"
-            ref="ihrChartDisco"
-          />
-        </q-card-section>
-      </q-card>
-    </q-expansion-item>
+              <q-item-section>
+                <a id="linkDelay"></a>
+                <div class="text-primary text-grey">
+                  {{ $t('charts.delayAndForwarding.title') }}
+                </div>
+                <div class="text-caption text-grey">Traceroute data</div>
+              </q-item-section>
+            </q-item-section>
+            <q-item-section class="filter-div">
+              <div class="text" v-if="linkExpanded">
+                <q-input debounce="300" v-model="linkFilter" placeholder="Filter">
+                  <template v-slot:append>
+                    <q-icon name="fas fa-filter" />
+                  </template>
+                </q-input>
+              </div>
+            </q-item-section>
+          </div>
+        </template>
+      </q-expansion-item>
+    </div>
+    <div v-show="this.nbAlarms['linkDelay']">
+      <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="linkExpanded">
+        <template v-slot:header>
+          <div class="graph-header-div">
+            <q-item-section class="graph-header">
+              <q-item-section avatar>
+                <q-icon name="fas fa-exchange-alt" color="primary" text-color="white" />
+              </q-item-section>
+
+              <q-item-section>
+                <a id="linkDelay"></a>
+                <div class="text-primary">
+                  {{ $t('charts.delayAndForwarding.title') }}
+                </div>
+                <div class="text-caption text-grey">Traceroute data</div>
+              </q-item-section>
+            </q-item-section>
+            <q-item-section class="filter-div">
+              <div class="text" v-if="linkExpanded">
+                <q-input debounce="300" v-model="linkFilter" placeholder="Filter">
+                  <template v-slot:append>
+                    <q-icon name="fas fa-filter" />
+                  </template>
+                </q-input>
+              </div>
+            </q-item-section>
+          </div>
+        </template>
+        <q-card class="IHR_charts-body">
+          <q-card-section>
+            <delay-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" :min-nprobes="minNprobes"
+              :min-deviation="minDeviation" :min-diffmedian="minDiffmedian" :max-diffmedian="maxDiffmedian"
+              :filter="linkFilter" @filteredRows="newFilteredRows('linkDelay', $event)" @loading="linkDelayLoading"
+              :selected-asn="asnList" ref="ihrChartDelay" @prefix-details="showDetails($event)" />
+          </q-card-section>
+        </q-card>
+      </q-expansion-item>
+    </div>
+    <div v-show="!this.nbAlarms['disco']">
+      <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="ndelayExpanded">
+        <template v-slot:header>
+          <div class="graph-header-div">
+            <q-item-section class="graph-header">
+              <q-item-section avatar>
+                <q-icon name="fas fa-plug" color="primary" text-color="white" />
+              </q-item-section>
+
+              <q-item-section>
+                <a id="disco"></a>
+                <div class="text-primary text-grey">
+                  {{ $t('charts.disconnections.title') }}
+                </div>
+                <div class="text-caption text-grey">RIPE Atlas log</div>
+              </q-item-section>
+            </q-item-section>
+            <q-item-section class="filter-div">
+              <div class="text" v-if="discoExpanded">
+                <q-input debounce="300" v-model="discoFilter" placeholder="Filter">
+                  <template v-slot:append>
+                    <q-icon name="fas fa-filter" />
+                  </template>
+                </q-input>
+              </div>
+            </q-item-section>
+          </div>
+        </template>
+      </q-expansion-item>
+    </div>
+    <div v-show="this.nbAlarms['disco']">
+      <q-expansion-item caption="RIPE Atlas log" header-class="IHR_charts-title" default-opened expand-icon-toggle
+        v-model="discoExpanded">
+        <template v-slot:header>
+          <div class="graph-header-div">
+            <q-item-section class="graph-header">
+              <q-item-section avatar>
+                <q-icon name="fas fa-plug" color="primary" text-color="white" />
+              </q-item-section>
+
+              <q-item-section>
+                <a id="disco"></a>
+                <div class="text-primary">
+                  {{ $t('charts.disconnections.title') }}
+                </div>
+                <div class="text-caption text-grey">RIPE Atlas log</div>
+              </q-item-section>
+            </q-item-section>
+            <q-item-section class="filter-div">
+              <div class="text" v-if="discoExpanded">
+                <q-input debounce="300" v-model="discoFilter" placeholder="Filter">
+                  <template v-slot:append>
+                    <q-icon name="fas fa-filter" />
+                  </template>
+                </q-input>
+              </div>
+            </q-item-section>
+          </div>
+        </template>
+
+        <q-card class="IHR_charts-body">
+          <q-card-section>
+            <disco-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" :min-avg-level="minAvgLevel"
+              :geoprobes.sync="geoProbes" :filter="discoFilter" @filteredRows="newFilteredRows('disco', $event)"
+              @loading="discoLoading" :selected-asn="asnList" ref="ihrChartDisco" />
+          </q-card-section>
+        </q-card>
+      </q-expansion-item>
+    </div>
   </div>
 </template>
 
@@ -312,6 +407,12 @@ export default {
       asnList: [],
       asnListState: REPORT_TYPE.GLOBAL,
       geoProbes: [],
+      // hideValue: {
+      //   hegemony: 0,
+      //   networkDelay: 0,
+      //   linkDelay: 0,
+      //   disco: 0,
+      // },
       nbAlarms: {
         hegemony: 0,
         networkDelay: 0,
@@ -386,8 +487,16 @@ export default {
       if (this.globalFilter == search) {
         this.$nextTick(function () {
           this.nbAlarms[graphType] = rows.length
+
         })
+
       }
+
+      // if (this.nbAlarms['networkDelay'] > 0) {
+      //   this.hideValue['networkDelay'] = false
+      // } else {
+      //   this.hideValue['networkDelay'] = true
+      // }
     },
     generateReport() {
       let element = document.getElementById('IHR_as-and-ixp-container')


### PR DESCRIPTION
Was able to solve issue #310, by using vue logic and will now be able to see only relevant tables.

## Description
Explored the whole structure and obtained the code that could potentially be used to determine whether or not one would be able to accomplish the task and settled on using the values of the alarms and v-show.

## Motivation and Context

#310 

## How Has This Been Tested?

I have tested it with several known and unknown search terms to determine correct working with the lowest possible latency.

## Screenshots (if appropriate):

#### Blank search
![image](https://user-images.githubusercontent.com/72858215/224085777-fbcbdd60-398c-4798-8d1c-062ea8e691b3.png)

#### Search 'usa'
![image](https://user-images.githubusercontent.com/72858215/224086003-726acdb0-d971-4ff2-8078-7a61a2f136c0.png)

#### Search 'iran'
![image](https://user-images.githubusercontent.com/72858215/224086095-c67b1050-32d9-4e89-ba12-edad9a215856.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
