### PR TITLE
Solves Issue #332, bugfix: Invalid proptype being passed

### DIFF
--- a/src/views/Countries.vue
+++ b/src/views/Countries.vue
@@ -98,7 +98,7 @@
         <h1 class="text-center q-pa-xl">Country Report</h1>
         <div class="row justify-center">
           <div class="col-6">
-            <network-search-bar bg="white" label="grey-8" input="black" labelTxt="Enter a country name" noAS="true" />
+            <network-search-bar bg="white" label="grey-8" input="black" labelTxt="Enter a country name" noAS={{ true }} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
#332 Fixed: Wrong value passed as prop to network-search-bar

noAs is a prop which is of type Boolean but "true" was being passed previously which is String, hence the error.

Before fix: noAs="true"
After fix: noAs={{ true }}