### PR TITLE
Solves #334 bugfix: fixed network delay dropdown not closing

### DIFF
--- a/src/views/Countries.vue
+++ b/src/views/Countries.vue
@@ -84,7 +84,6 @@
                 :clear="clear"
                 searchBar
                 ref="networkDelayChart"
-                @display="displayNetDelay"
               />
             </q-card-section>
           </q-card>


### PR DESCRIPTION
#334 Dropdown for Network delay not getting closed 

The expand section for network delay was not getting closed unlike the other two, Network dependency and route origin validation. 
It was opening again instantly on closing it.

This got fixed by removing  ' @display="displayNetDelay" ' which was passed to the network-delay-chart component.

Please review and merge it. Thanks!
