### PR TITLE
Solves #336 Fixed typos in reports dropdown in header

### DIFF
--- a/src/views/Header.vue
+++ b/src/views/Header.vue
@@ -69,7 +69,7 @@
 <script>
 import NetworkSearchBar from '@/components/search_bar/NetworkSearchBar'
 
-const simple_menu = [
+let simple_menu = [
   {
     entryName: 'header.home',
     routeName: 'home',
@@ -86,7 +86,7 @@ const simple_menu = [
       {
         entryName: 'header.countryReport',
         routeName: 'countries',
-        summary: 'Overview of Internet ressources per country',
+        summary: 'Overview of Internet resources per country',
       },
       {
         entryName: 'header.networkReport',
@@ -96,7 +96,7 @@ const simple_menu = [
       {
         entryName: 'header.rovReport',
         routeName: 'rov',
-        summary: 'Route Origin Validation of ressources seen on BGP',
+        summary: 'Route Origin Validation of resources seen on BGP',
       },
       {
         entryName: 'header.covid19',
@@ -139,7 +139,7 @@ export default {
   data() {
     return {
       text: '',
-      simple_menu: simple_menu,
+      simple_menu,
       sidebarOpened: false,
       loginError: false,
       leftDrawerOpen: false,


### PR DESCRIPTION
Solves issue #336 
There were typo errors in the reports dropdown in Header.

'Resources' were spelled as 'Ressources'

I have fixed them now. Please review it.
Thanks!