### PR TITLE
Converted y-axis labels of AS-dependency chart to percentage

### DIFF
--- a/src/views/charts/layouts.js
+++ b/src/views/charts/layouts.js
@@ -74,6 +74,7 @@ var AS_INTERDEPENDENCIES_LAYOUT = {
     title: '',
     domain: [0.6, 1],
     range: [0, 101],
+    ticksuffix: "%"
   },
   yaxis2: {
     domain: [0, 0.4],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The y-axis values for the AS-hegemony chart was in numbers now it is changed to percentage.
Solves the second part of issue #126.

## Screenshots :

![image](https://user-images.githubusercontent.com/99183441/225440092-4344208f-f532-42a8-8a3c-11441a4769c6.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
