### PR TITLE
feature/Replace document.getElementById with $refs for accessing DOM elements in Vue js scripts

### DIFF
--- a/src/components/ripe/mixins/PrefixMixin.vue
+++ b/src/components/ripe/mixins/PrefixMixin.vue
@@ -4,7 +4,7 @@
       <q-spinner color="secondary" size="2em" />
       Loading RIPEstat widgets...
     </div>
-    <div :id="myId"></div>
+    <div :id="myId" :ref="myId"></div>
   </div>
 </template>
 <script>
@@ -34,8 +34,7 @@ export default {
     navigateAndRemove() {
       if (!this.removeStyle) return
       this.$libraryDelayer.getRidOfInlineStyle(this.myId, '*')
-      var elemt = document.getElementById(this.myId)
-      elemt.style.width = '100%'
+      this.$refs[this.myId].style.width = '100%'
       this.loaded = true
     },
   },

--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="IHR_as-and-ixp-container">
+  <div id="IHR_as-and-ixp-container" ref="ihrAsAndIxpContainer">
     <div>
       <h1 class="text-center">Network Delays During National Lockdowns</h1>
 
@@ -163,7 +163,7 @@ export default {
       this.yMax = this.yMax > newMaxY ? this.yMax : newMaxY
     },
     generateReport() {
-      let element = document.getElementById('IHR_as-and-ixp-container')
+      let element = this.$refs['ihrAsAndIxpContainer']
       let opt = {
         margin: 0,
         filename: 'Corona.pdf',

--- a/src/views/Countries.vue
+++ b/src/views/Countries.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="IHR_as-and-ixp-container" class="IHR_char-container">
+  <div id="IHR_as-and-ixp-container" ref="ihrAsAndIxpContainer" class="IHR_char-container">
     <div v-if="countryCode">
       <div>
         <h1 class="text-center">{{ headerString }}</h1>
@@ -226,7 +226,7 @@ export default {
       this.majorEyeballs = tmp
     },
     generateReport() {
-      let element = document.getElementById('IHR_as-and-ixp-container')
+      let element = this.$refs['ihrAsAndIxpContainer']
       let opt = {
         margin: 0,
         filename: 'Countries.pdf',

--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="IHR_as-and-ixp-container" class="IHR_char-container">
+  <div id="IHR_as-and-ixp-container" ref="ihrAsAndIxpContainer" class="IHR_char-container">
     <div class="q-mb-xs">
       <div class="text-center">
         <div class="text-h1">{{ title }}</div>
@@ -499,7 +499,7 @@ export default {
       // }
     },
     generateReport() {
-      let element = document.getElementById('IHR_as-and-ixp-container')
+      let element = this.$refs['ihrAsAndIxpContainer']
       let opt = {
         margin: 0,
         filename: 'GlobalReport.pdf',

--- a/src/views/Networks.vue
+++ b/src/views/Networks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="IHR_as-and-ixp-container" class="IHR_char-container">
+  <div id="IHR_as-and-ixp-container" ref="ihrAsAndIxpContainer" class="IHR_char-container">
     <div v-if="asNumber">
       <div>
         <h1 class="text-center">{{ subHeader }} - {{ headerString }}</h1>
@@ -322,7 +322,7 @@ export default {
       })
     },
     generateReport() {
-      let element = document.getElementById('IHR_as-and-ixp-container')
+      let element = this.$refs['ihrAsAndIxpContainer']
       let opt = {
         margin: 0,
         filename: 'Networks.pdf',

--- a/src/views/ROV.vue
+++ b/src/views/ROV.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="IHR_as-and-ixp-container" class="IHR_char-container">
+  <div id="IHR_as-and-ixp-container" ref="ihrAsAndIxpContainer" class="IHR_char-container">
     <div>
       <h1 class="text-center"><q-icon name="fas fa-route" />&nbsp; Route Origin Validation</h1>
       <h3 class="text-center">
@@ -87,7 +87,7 @@ export default {
       this.majorEyeballs = tmp
     },
     generateReport() {
-      let element = document.getElementById('IHR_as-and-ixp-container')
+      let element = this.$refs['ihrAsAndIxpContainer']
       let opt = {
         margin: 0,
         filename: 'ROV.pdf',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request fixes the issue #348 basically replaces the usage of `document.getElementById()` with Vue.js's `$refs` property in the Vue js scripts in `src/views` directory.

## Motivation and Context

This change is required to improve the readability and maintainability of the Vue js scripts, as well as make it easier to modify and add new features in the future. Currently, the Vue js scripts use vanilla JavaScript's `document.getElementById()` to access and manipulate DOM elements. While this approach works, it can make the code harder to maintain and modify in the future.

## How Has This Been Tested?

This change has been tested by running the affected Vue js scripts and ensuring that they still function as expected. No other areas of the code were affected.

## Screenshots (if appropriate):
None.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

