### PR TITLE
issue 328 : possible typo in header dropdown menu solved

### DIFF
--- a/src/views/Header.vue
+++ b/src/views/Header.vue
@@ -86,7 +86,7 @@ const simple_menu = [
       {
         entryName: 'header.countryReport',
         routeName: 'countries',
-        summary: 'Overview of Internet ressources per country',
+        summary: 'Overview of Internet resources per country',
       },
       {
         entryName: 'header.networkReport',
@@ -96,7 +96,7 @@ const simple_menu = [
       {
         entryName: 'header.rovReport',
         routeName: 'rov',
-        summary: 'Route Origin Validation of ressources seen on BGP',
+        summary: 'Route Origin Validation of resources seen on BGP',
       },
       {
         entryName: 'header.covid19',


### PR DESCRIPTION
As issue stated there was a typo in word "resources" in src/views/Header.vue

## Description

Earlier the word was "ressources" in the file Header.vue in english, but it should "resources" as a correct grammer for that word.
homepage > reports (menu bar ) > country  "overview of internet **resources** per country

## Motivation and Context

This pull request solves the grammatical error in resources word in the webpage 

issue 328 : https://github.com/InternetHealthReport/ihr-website/issues/328

## How Has This Been Tested?

This was tested by running again the web page on the local server by 

npm run serve  command

## Screenshots (if appropriate):

![Screenshot 2023-03-21 180205](https://user-images.githubusercontent.com/80171589/226606938-b545eca3-a3c7-4bb7-afa3-5bbd57ec21a7.png)


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
