### PR TITLE
Fix: disabled translation warnings in console

### DIFF
--- a/src/locales/i18n.js
+++ b/src/locales/i18n.js
@@ -21,6 +21,7 @@ let vueI18n = new VueI18n({
   locale: process.env.VUE_APP_I18N_LOCALE || 'en-us',
   fallbackLocale: process.env.VUE_APP_I18N_FALLBACK_LOCALE || 'en-us',
   messages: loadLocaleMessages(),
+  silentTranslationWarn:true
 })
 
 const INTERPOLATION_REGEXP = /^{([^}]+)}|{([^}]+)}/g


### PR DESCRIPTION
Solves Issue #338 

vue-i18n logs the following as a warning whenever a translation is not found.
For Example:
`[vue-i18n] Cannot translate the value of keypath 'Overview of Internet ressources per country'. Use the value of keypath as default.` 
![image](https://user-images.githubusercontent.com/87076033/226942238-1cb36681-9327-4a66-ace5-13e5f719d08c.png)

It is not desirable to spam the console with a bunch of warnings.

It can be solved by adding silentTranslationWarn line to the new instance of vueI18n created in i18n.js file