### PR TITLE
fixes #370: plural spelling for destination always

### DIFF
--- a/src/views/charts/tables/NetworkDelayAlarmsTable.vue
+++ b/src/views/charts/tables/NetworkDelayAlarmsTable.vue
@@ -182,7 +182,8 @@ export default {
       this.rows = values
     },
     destinationsSubtitle(val) {
-      return String(Object.keys(val).length) + ' ' + this.$t('charts.networkDelayAlarms.table.destinations')
+      if(Object.keys(val).length===1)return String(Object.keys(val).length) + ' ' + this.$t('charts.networkDelayAlarms.table.destinations').slice(0,-1)
+      return String(Object.keys(val).length) + ' ' + this.$t('charts.networkDelayAlarms.table.destinations');
     },
     destinationsBody(val) {
       var body = ''


### PR DESCRIPTION
Solves #370 
In Network Delay Chart, in the table, there is a column to show the number of destinations.
Currently after the number of destinations, we use destinations suffix for any number of destination, ie. even if there is only 1 Destination, we use "1 destinations" which is a bit weird.

I have fixed this using Javascript by checking the number of destinations.

Before:
![image](https://user-images.githubusercontent.com/87076033/227777484-4fc65153-8f2d-418e-80ca-25750889c8d4.png)

After fix:
![image](https://user-images.githubusercontent.com/87076033/227777438-b4b6bbd3-29fb-4243-8e49-19abfdec78a8.png)

