### PR TITLE
Fix #372: Improper casing used in loading and also fixed a typo

### DIFF
--- a/src/locales/langs/en-us.json
+++ b/src/locales/langs/en-us.json
@@ -64,12 +64,12 @@
   },
   "Networks": {
     "headerString": {
-      "loading": "Loading in progress...",
+      "loading": "loading in progress...",
       "notFound": "AS doesn't exists",
       "expired": "Request expired"
     },
     "subHeader": {
-      "loading": "please wait",
+      "loading": "Please wait",
       "notFound": "The queried network",
       "expired": "the sever is under load, please try again later"
     }

--- a/src/locales/langs/en-us.json
+++ b/src/locales/langs/en-us.json
@@ -71,7 +71,7 @@
     "subHeader": {
       "loading": "Please wait",
       "notFound": "The queried network",
-      "expired": "the sever is under load, please try again later"
+      "expired": "the server is under load, please try again later"
     }
   },
   "charts": {


### PR DESCRIPTION
Fixes #372 and a typo 
When we select a network to produce reports, while the data loads, there comes a message "please wait - Loading in progress..." which is not using proper letter casing.

Also fixed a typo of "server" in the same file 
 Before fix: 
![image](https://user-images.githubusercontent.com/87076033/227778201-f58c458a-ebbd-4353-87c4-07890881ac58.png)

After fix:
![image](https://user-images.githubusercontent.com/87076033/227778207-3d04d563-4eff-411e-80fe-ad6ec66a112f.png)

@romain-fontugne @Aniket762 Please merge this if found necessary.
Thanks!
