### PR TITLE
feat: revert changes in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "serve": "set NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve",
-    "build": "set NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
-    "test:unit": "set NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service test:unit",
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build",
+    "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint --no-fix",
     "lint:fix": "vue-cli-service lint",
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
     "prepare": "husky install"
   },
-
   "dependencies": {
     "@quasar/extras": "^1.5.2",
     "autoprefixer": "^9.6.5",


### PR DESCRIPTION


## Description

Reverting #254 

## Motivation and Context

- We don't need to set the environment variable to include the `--openssl-legacy-provider` anymore, with the compiling warnings being fixed and the readme being updated with the required instructions.

- Contributors were having issues as it was giving compilation errors in Windows, as it needs to be added in the env manually, which is an unnecessary step.


## How Has This Been Tested?

I've tested the changes in both Linux and Windows and will successfully run on mac too.

## Screenshots (if appropriate):

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. 


