### PR TITLE
Bug#375 Fixed button styling and moved toolbox section to top

### DIFF
--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -33,6 +33,12 @@
           <q-select v-model="selected" :options="selection" label="Select a country" />
         </div>
       </div>
+      <div class="row toolbox">
+        <div class="offset-10">
+          <h3>Toolbox</h3>
+          <q-toggle v-model="searchBar" label="Add more destination networks" />
+        </div>
+      </div>
       <div v-if="selected">
         <div class="row justify-center q-pa-xl">
           <div class="col-4">
@@ -105,12 +111,6 @@
                 :searchBar="searchBar"
               />
             </div>
-          </div>
-        </div>
-        <div class="row self-end">
-          <div class="col-2 offset-10">
-            <h3>Toolbox</h3>
-            <q-toggle v-model="searchBar" label="Add more destination networks" />
           </div>
         </div>
       </div>
@@ -228,4 +228,8 @@ export default {
     position relative
     top -250px
     visibility hidden
+.toolbox
+    margin-right 12pt
+    margin-top 15pt
+    
 </style>

--- a/src/views/charts/NetworkDelayChart.vue
+++ b/src/views/charts/NetworkDelayChart.vue
@@ -13,8 +13,8 @@
         <location-search-bar @select="addEndLocation" :hint="$t('searchBar.locationDestination')" :label="$t('searchBar.locationHint')" />
       </div>
       <div class="col-3 q-pa-sm">
-        <q-btn @click="debouncedApiCall" color="secondary" class="q-ml-sm">Add</q-btn>
-        <q-btn @click="clearGraph" class="q-ml-sm">Clear all</q-btn>
+        <q-btn @click="debouncedApiCall" color="secondary" class="btn">Add</q-btn>
+        <q-btn @click="clearGraph" class="btn">Clear all</q-btn>
       </div>
     </div>
     <div class="row">
@@ -417,4 +417,8 @@ export default {
   &hidden-bar
     top 60px
     opacity 0
+.btn
+    margin-bottom 10pt
+    width 80pt
+    margin-right 10pt
 </style>


### PR DESCRIPTION
Button styling changed and made more consistent with the Add button in covid19 section.
Before:
![image](https://user-images.githubusercontent.com/87076033/228770444-00dac927-8d02-4753-bda6-6c93efd4d600.png)
After:
![image](https://user-images.githubusercontent.com/87076033/228770615-d6d5146a-3a89-4b71-b859-73376ff5ffc7.png)

Also I have moved the toolbox section to the top for easy visibility :
Before:
![image](https://user-images.githubusercontent.com/87076033/228771216-a3aa7d30-cc0f-491d-8263-b1858a16efc4.png)
After:
![image](https://user-images.githubusercontent.com/87076033/228771353-600e6e88-197e-4f26-8687-08c46a5fe871.png)

Thanks!
