### PR TITLE
Bug#376 Changed search box layout when there is less space 

### DIFF
--- a/src/components/search_bar/LocationSearchBar.vue
+++ b/src/components/search_bar/LocationSearchBar.vue
@@ -5,7 +5,7 @@
     clearable
     dense
     outlined
-    :label="label"
+    :placeholder="!model?label:''"
     :options="options"
     v-model="model"
     @filter="filter"
@@ -16,7 +16,7 @@
   >
     <template v-slot:append>
       <div v-if="!loading">
-        <q-icon name="fas fa-search" style="font-size: 0.82em; margin-rigth: 4px" />
+        <q-icon name="fas fa-search" style="font-size: 0.82em; margin-right: 4px" />
       </div>
       <div v-else>
         <q-spinner color="primary" size="0.82em" />

--- a/src/views/charts/NetworkDelayChart.vue
+++ b/src/views/charts/NetworkDelayChart.vue
@@ -1,34 +1,53 @@
 <template>
   <div class="IHR_chart">
     <div class="justify-center" v-if="searchBar">
-      <div>
-      <div class="q-pa-sm"
-      >
-        <location-search-bar
-          @select="addStartLocation"
-          :hint="$t('searchBar.locationSource')"
-          :label="$t('searchBar.locationHint')"
+      <div v-if="isCovid">
+        <div class="q-pa-sm"
+        >
+          <location-search-bar
+            @select="addStartLocation"
+            :hint="$t('searchBar.locationSource')"
+            :label="$t('searchBar.locationHint')"
+            :selected="startPointNameStr"
+            style="width: 65%;margin: auto; margin-bottom: -6px;"
+            />
+        </div>
+        <div class="q-pa-sm"
+        >
+          <location-search-bar 
+          @select="addEndLocation" 
+          :hint="$t('searchBar.locationDestination')" 
+          :label="$t('searchBar.locationHint')" 
           :selected="startPointNameStr"
-          style="width: 65%;margin: auto; margin-bottom: -6px;"
+          style="width: 65%;margin: auto;margin-bottom: -6px;"
           />
-      </div>
-      <div class="q-pa-sm"
-      >
-        <location-search-bar 
-        @select="addEndLocation" 
-        :hint="$t('searchBar.locationDestination')" 
-        :label="$t('searchBar.locationHint')" 
-        :selected="startPointNameStr"
-        style="width: 65%;margin: auto;margin-bottom: -6px;"
-        />
-      </div>
-      </div>
-      <div style="display: block;">
+        </div>
+        <div style="display: block;">
       <div class="col-3 q-pa-sm">
         <q-btn @click="debouncedApiCall" color="secondary" class="q-ml-sm">Add</q-btn>
         <q-btn @click="clearGraph" class="q-ml-sm">Clear all</q-btn>
       </div>
       </div>
+      </div>
+      <div v-else>
+        <div class="row justify-center">
+      <div class="col-4 q-pa-sm">
+        <location-search-bar
+          @select="addStartLocation"
+          :hint="$t('searchBar.locationSource')"
+          :label="$t('searchBar.locationHint')"
+          :selected="startPointNameStr"
+        />
+      </div>
+      <div class="col-4 q-pa-sm">
+        <location-search-bar @select="addEndLocation" :hint="$t('searchBar.locationDestination')" :label="$t('searchBar.locationHint')" />
+      </div>
+      <div class="col-3 q-pa-sm">
+        <q-btn @click="debouncedApiCall" color="secondary" class="q-ml-sm">Add</q-btn>
+        <q-btn @click="clearGraph" class="q-ml-sm">Clear all</q-btn>
+      </div>
+      </div>
+    </div>
     </div>
     <div class="row">
       <div class="col">
@@ -363,6 +382,9 @@ export default {
     },
   },
   computed: {
+    isCovid(){
+      return window.location.href.includes('covid')
+    },
     delayUrl() {
       return this.$ihr_api.getUrl(this.apiFilter)
     },

--- a/src/views/charts/NetworkDelayChart.vue
+++ b/src/views/charts/NetworkDelayChart.vue
@@ -1,20 +1,33 @@
 <template>
   <div class="IHR_chart">
-    <div class="row justify-center" v-if="searchBar">
-      <div class="col-4 q-pa-sm">
+    <div class="justify-center" v-if="searchBar">
+      <div>
+      <div class="q-pa-sm"
+      >
         <location-search-bar
           @select="addStartLocation"
           :hint="$t('searchBar.locationSource')"
           :label="$t('searchBar.locationHint')"
           :selected="startPointNameStr"
+          style="width: 65%;margin: auto; margin-bottom: -6px;"
+          />
+      </div>
+      <div class="q-pa-sm"
+      >
+        <location-search-bar 
+        @select="addEndLocation" 
+        :hint="$t('searchBar.locationDestination')" 
+        :label="$t('searchBar.locationHint')" 
+        :selected="startPointNameStr"
+        style="width: 65%;margin: auto;margin-bottom: -6px;"
         />
       </div>
-      <div class="col-4 q-pa-sm">
-        <location-search-bar @select="addEndLocation" :hint="$t('searchBar.locationDestination')" :label="$t('searchBar.locationHint')" />
       </div>
+      <div style="display: block;">
       <div class="col-3 q-pa-sm">
         <q-btn @click="debouncedApiCall" color="secondary" class="q-ml-sm">Add</q-btn>
         <q-btn @click="clearGraph" class="q-ml-sm">Clear all</q-btn>
+      </div>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Fixes #376 : Changed search box styling and layout in network delay charts.
In network delay chart under the covid19 section, before there was less space for the boxes and was looking crowdy. So I have moved each search box to separate line while keeping the same previous design when there is more space.

Before:
![image](https://user-images.githubusercontent.com/87076033/228911414-119cd111-b536-4486-99fd-71a8a3fc3004.png)
 After: 
![image](https://user-images.githubusercontent.com/87076033/228911542-9e8f8e8a-75fa-47f2-bc74-a3dd6fc3a65c.png)

Also, I have applied placeholder to the search boxes which appear only when there is no input in that.
![image](https://user-images.githubusercontent.com/87076033/228911851-71feb173-c175-4f34-adc5-803383761f3c.png)

Thanks!