### PR TITLE
Fixed #395 : Added scrollbar to tables with many records

### DIFF
--- a/src/styles/charts/common.styl
+++ b/src/styles/charts/common.styl
@@ -64,3 +64,19 @@
 .q-td
     white-space: normal !important;
 
+.scroller
+    max-height 300pt
+    overflow-y auto
+
+.scroller ::-webkit-scrollbar 
+  width: 9px;
+  
+.scroller ::-webkit-scrollbar-track 
+  background: lightgray
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller ::-webkit-scrollbar-thumb 
+  background: #c0c3c3;
+  border-radius 6pt

--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -178,7 +178,7 @@
         </template>
         <q-card class="IHR_charts-body">
           <q-card-section>
-            <network-delay-alarms-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" class="scroller"
+            <network-delay-alarms-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" class=""
               :min-deviation="minDeviationNetworkDelay" :filter="ndelayFilter"
               @filteredRows="newFilteredRows('networkDelay', $event)" @loading="networkDelayLoading"
               ref="ihrChartNetworkDelay" />
@@ -246,7 +246,7 @@
         </template>
         <q-card class="IHR_charts-body">
           <q-card-section>
-            <delay-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" :min-nprobes="minNprobes" class="scroller"
+            <delay-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" :min-nprobes="minNprobes" class=""
               :min-deviation="minDeviation" :min-diffmedian="minDiffmedian" :max-diffmedian="maxDiffmedian"
               :filter="linkFilter" @filteredRows="newFilteredRows('linkDelay', $event)" @loading="linkDelayLoading"
               :selected-asn="asnList" ref="ihrChartDelay" @prefix-details="showDetails($event)" />
@@ -540,22 +540,6 @@ export default {
 
 <style lang="stylus">
 @import '../styles/quasar.variables';
-.scroller
-    max-height 300pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar 
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track 
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb 
-  background: #c3c3c3;
-  border-radius 6pt
   
 .stat-grid
   display: grid;

--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -115,11 +115,11 @@
           </div>
         </template>
         <q-card class="IHR_charts-body">
-          <q-card-section>
-            <hegemony-alarms-chart :start-time="startTime" :end-time="endTime" :fetch="fetch"
-              :min-deviation="minDeviationNetworkDelay" :filter="hegemonyFilter"
-              @filteredRows="newFilteredRows('hegemony', $event)" @loading="hegemonyLoading"
-              ref="ihrChartHegemonyAlarms" />
+          <q-card-section >
+            <hegemony-alarms-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" class="scroller"
+            :min-deviation="minDeviationNetworkDelay" :filter="hegemonyFilter"
+            @filteredRows="newFilteredRows('hegemony', $event)" @loading="hegemonyLoading"
+            ref="ihrChartHegemonyAlarms" />
           </q-card-section>
         </q-card>
       </q-expansion-item>
@@ -178,7 +178,7 @@
         </template>
         <q-card class="IHR_charts-body">
           <q-card-section>
-            <network-delay-alarms-chart :start-time="startTime" :end-time="endTime" :fetch="fetch"
+            <network-delay-alarms-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" class="scroller"
               :min-deviation="minDeviationNetworkDelay" :filter="ndelayFilter"
               @filteredRows="newFilteredRows('networkDelay', $event)" @loading="networkDelayLoading"
               ref="ihrChartNetworkDelay" />
@@ -246,7 +246,7 @@
         </template>
         <q-card class="IHR_charts-body">
           <q-card-section>
-            <delay-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" :min-nprobes="minNprobes"
+            <delay-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" :min-nprobes="minNprobes" class="scroller"
               :min-deviation="minDeviation" :min-diffmedian="minDiffmedian" :max-diffmedian="maxDiffmedian"
               :filter="linkFilter" @filteredRows="newFilteredRows('linkDelay', $event)" @loading="linkDelayLoading"
               :selected-asn="asnList" ref="ihrChartDelay" @prefix-details="showDetails($event)" />
@@ -316,7 +316,7 @@
 
       <q-card class="IHR_charts-body">
         <q-card-section>
-          <disco-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" :min-avg-level="minAvgLevel"
+          <disco-chart :start-time="startTime" :end-time="endTime" :fetch="fetch" :min-avg-level="minAvgLevel" 
             :geoprobes.sync="geoProbes" :filter="discoFilter" @filteredRows="newFilteredRows('disco', $event)"
             @loading="discoLoading" :selected-asn="asnList" ref="ihrChartDisco" />
         </q-card-section>
@@ -540,6 +540,23 @@ export default {
 
 <style lang="stylus">
 @import '../styles/quasar.variables';
+.scroller
+    max-height 300pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar 
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track 
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb 
+  background: #c3c3c3;
+  border-radius 6pt
+  
 .stat-grid
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -640,4 +657,5 @@ export default {
           letter-spacing -7px
           */
           cursor pointer
+  
 </style>

--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -29,25 +29,25 @@
             <a href="#hegemony" class="IHR_global_stats">
               <q-spinner v-if="loading.hegemony" color="primary" size="1em" />
               <b v-else>{{ nbAlarms.hegemony }}</b>
-              AS dependency alarms
+              AS Dependency Alarms
             </a>
           </div>
           <div class="stat-tab text-center text-h3">
             <a href="#networkDelay" class="IHR_global_stats">
               <q-spinner v-if="loading.networkDelay" color="primary" size="1em" />
-              <b v-else>{{ nbAlarms.networkDelay }}</b> network delay alarms
+              <b v-else>{{ nbAlarms.networkDelay }}</b> Network Delay Alarms
             </a>
           </div>
           <div class="stat-tab text-center text-h3">
             <a href="#linkDelay" class="IHR_global_stats">
               <q-spinner v-if="loading.linkDelay" color="primary" size="1em" />
-              <b v-else>{{ nbAlarms.linkDelay }}</b> link delay alarms
+              <b v-else>{{ nbAlarms.linkDelay }}</b> Link Delay Alarms
             </a>
           </div>
           <div class="stat-tab text-center text-h3">
             <a href="#disco" class="IHR_global_stats">
               <q-spinner v-if="loading.disco" color="primary" size="1em" />
-              <b v-else>{{ nbAlarms.disco }}</b> network disconnections
+              <b v-else>{{ nbAlarms.disco }}</b> Network Disconnections
             </a>
           </div>
         </div>

--- a/src/views/charts/tables/AsInterdependenciesTable.vue
+++ b/src/views/charts/tables/AsInterdependenciesTable.vue
@@ -144,21 +144,4 @@ export default {
   },
 }
 </script>
-<style lang="stylus">
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
-</style>
+<style lang="stylus"></style>

--- a/src/views/charts/tables/AsInterdependenciesTable.vue
+++ b/src/views/charts/tables/AsInterdependenciesTable.vue
@@ -1,5 +1,7 @@
 <template>
-  <q-table :data="rows" :columns="columns" row-key="asNumber" :pagination.sync="pagination" :loading="loading" binary-state-sort flat>
+  <q-table :data="rows" :columns="columns" row-key="asNumber" :pagination.sync="pagination" :loading="loading" binary-state-sort flat 
+  class="scroller"
+  >
     <template v-slot:body="props">
       <q-tr :props="props" @click.native="routeToAsn(props.colsMap.asNumber, props.row)" class="IHR_table-row">
         <q-td
@@ -142,4 +144,21 @@ export default {
   },
 }
 </script>
-<style lang="stylus"></style>
+<style lang="stylus">
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
+</style>

--- a/src/views/charts/tables/CountryHegemonyTable.vue
+++ b/src/views/charts/tables/CountryHegemonyTable.vue
@@ -149,21 +149,4 @@ export default {
   },
 }
 </script>
-<style lang="stylus">
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
-</style>
+<style lang="stylus"></style>

--- a/src/views/charts/tables/CountryHegemonyTable.vue
+++ b/src/views/charts/tables/CountryHegemonyTable.vue
@@ -10,6 +10,7 @@
     separator="vertical"
     binary-state-sort
     flat
+    class="scroller"
   >
     <div slot="header" slot-scope="props" style="display: contents">
       <q-tr>
@@ -47,7 +48,7 @@
       </q-tr>
     </div>
     <template v-slot:body="props">
-      <q-tr :props="props" @click.native="routeToAsn(props.colsMap.asNumber, props.row)" class="IHR_table-row">
+      <q-tr :props="props" @click.native="routeToAsn(props.colsMap.asNumber, props.row)" class="IHR_table-row scroller">
         <q-td
           v-for="col in columns"
           :key="col.name"
@@ -148,4 +149,21 @@ export default {
   },
 }
 </script>
-<style lang="stylus"></style>
+<style lang="stylus">
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
+</style>

--- a/src/views/charts/tables/DelayAlarmsTable.vue
+++ b/src/views/charts/tables/DelayAlarmsTable.vue
@@ -10,6 +10,7 @@
     :filter-method="filterFct"
     :expanded.sync="expandedRow"
     loading-label="Fetching latest link delay alarms..."
+    class="scroller"
   >
     <template v-slot:body="props">
       <q-tr :props="props">
@@ -252,4 +253,19 @@ export default {
     border-color black
     max-width 600px
     min-width 300px
+    .scroller
+    max-height 350pt
+    overflow-y auto
+
+    .scroller::-webkit-scrollbar
+      width: 9px;
+  
+    .scroller::-webkit-scrollbar-track
+      background: lightgrey
+      border: 4px solid transparent;
+      background-clip: content-box;  
+  
+    .scroller::-webkit-scrollbar-thumb
+      background: #c3c3c3;
+      border-radius 6pt
 </style>

--- a/src/views/charts/tables/DelayAlarmsTable.vue
+++ b/src/views/charts/tables/DelayAlarmsTable.vue
@@ -253,19 +253,5 @@ export default {
     border-color black
     max-width 600px
     min-width 300px
-    .scroller
-    max-height 350pt
-    overflow-y auto
-
-    .scroller::-webkit-scrollbar
-      width: 9px;
   
-    .scroller::-webkit-scrollbar-track
-      background: lightgrey
-      border: 4px solid transparent;
-      background-clip: content-box;  
-  
-    .scroller::-webkit-scrollbar-thumb
-      background: #c3c3c3;
-      border-radius 6pt
 </style>

--- a/src/views/charts/tables/DiscoAlarmsTable.vue
+++ b/src/views/charts/tables/DiscoAlarmsTable.vue
@@ -11,6 +11,7 @@
     row-key="id"
     :expanded.sync="expandedRow"
     loading-label="Fetching the latest network disconnections..."
+    class="scroller"
   >
     <template v-slot:body="props">
       <q-tr :props="props">
@@ -201,4 +202,21 @@ export default {
 
     tbody td
         text-align left
+  
+.scroller
+    max-height 350pt
+    overflow-y auto
+    
+.scroller::-webkit-scrollbar
+    width: 9px;
+      
+.scroller::-webkit-scrollbar-track
+    background: lightgrey
+    border: 4px solid transparent;
+    background-clip: content-box;  
+      
+      
+.scroller::-webkit-scrollbar-thumb
+    background: #c3c3c3;
+    border-radius 6pt
 </style>

--- a/src/views/charts/tables/DiscoAlarmsTable.vue
+++ b/src/views/charts/tables/DiscoAlarmsTable.vue
@@ -203,20 +203,4 @@ export default {
     tbody td
         text-align left
   
-.scroller
-    max-height 350pt
-    overflow-y auto
-    
-.scroller::-webkit-scrollbar
-    width: 9px;
-      
-.scroller::-webkit-scrollbar-track
-    background: lightgrey
-    border: 4px solid transparent;
-    background-clip: content-box;  
-      
-      
-.scroller::-webkit-scrollbar-thumb
-    background: #c3c3c3;
-    border-radius 6pt
 </style>

--- a/src/views/charts/tables/DisconnectionTable.vue
+++ b/src/views/charts/tables/DisconnectionTable.vue
@@ -8,6 +8,7 @@
     flat
     :filter="filterTable"
     :filter-method="filterFct"
+    class="scroller"
   />
 </template>
 
@@ -68,4 +69,21 @@ export default {
 }
 </script>
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
+</style>

--- a/src/views/charts/tables/DisconnectionTable.vue
+++ b/src/views/charts/tables/DisconnectionTable.vue
@@ -69,21 +69,4 @@ export default {
 }
 </script>
 
-<style lang="stylus" scoped>
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
-</style>
+<style lang="stylus" scoped></style>

--- a/src/views/charts/tables/ForwardingAlarmsTable.vue
+++ b/src/views/charts/tables/ForwardingAlarmsTable.vue
@@ -81,21 +81,4 @@ export default {
   },
 }
 </script>
-<style lang="stylus">
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
-</style>
+<style lang="stylus"></style>

--- a/src/views/charts/tables/ForwardingAlarmsTable.vue
+++ b/src/views/charts/tables/ForwardingAlarmsTable.vue
@@ -8,6 +8,7 @@
     :filter="filterTable"
     :filter-method="filterFct"
     flat
+    class="scroller"
   >
     <template v-slot:body="props">
       <q-tr :props="props" @click.native="props.expand = !props.expand">
@@ -80,4 +81,21 @@ export default {
   },
 }
 </script>
-<style lang="stylus"></style>
+<style lang="stylus">
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
+</style>

--- a/src/views/charts/tables/HegemonyAlarmsTable.vue
+++ b/src/views/charts/tables/HegemonyAlarmsTable.vue
@@ -12,6 +12,7 @@
     row-key="originasn"
     :expanded.sync="expandedRow"
     loading-label="Fetching the latest network dependency alarms..."
+    class="scroller"
   >
     <template v-slot:body="props">
       <q-tr :props="props">
@@ -230,4 +231,21 @@ export default {
 
     tbody td
         text-align left
+
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
 </style>

--- a/src/views/charts/tables/HegemonyAlarmsTable.vue
+++ b/src/views/charts/tables/HegemonyAlarmsTable.vue
@@ -232,20 +232,4 @@ export default {
     tbody td
         text-align left
 
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
 </style>

--- a/src/views/charts/tables/MetisTable.vue
+++ b/src/views/charts/tables/MetisTable.vue
@@ -93,21 +93,4 @@ export default {
 }
 </script>
 
-<style lang="stylus">
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
-</style>
+<style lang="stylus"></style>

--- a/src/views/charts/tables/MetisTable.vue
+++ b/src/views/charts/tables/MetisTable.vue
@@ -8,6 +8,7 @@
     :filter="tabFilter"
     :loading="loading"
     flat
+    class="scroller"
   >
     <template v-slot:top>
       <div class="q-table__title">Selected ASes</div>
@@ -91,3 +92,22 @@ export default {
   },
 }
 </script>
+
+<style lang="stylus">
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
+</style>

--- a/src/views/charts/tables/NetworkDelayAlarmsTable.vue
+++ b/src/views/charts/tables/NetworkDelayAlarmsTable.vue
@@ -259,20 +259,4 @@ export default {
     tbody td
         text-align left
 
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
 </style>

--- a/src/views/charts/tables/NetworkDelayAlarmsTable.vue
+++ b/src/views/charts/tables/NetworkDelayAlarmsTable.vue
@@ -12,6 +12,7 @@
     row-key="asNumber"
     :expanded.sync="expandedRow"
     loading-label="Fetching latest network delay alarms..."
+    class="scroller"
   >
     <template v-slot:body="props">
       <q-tr :props="props">
@@ -257,4 +258,21 @@ export default {
 
     tbody td
         text-align left
+
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
 </style>

--- a/src/views/charts/tables/NetworkDelayTable.vue
+++ b/src/views/charts/tables/NetworkDelayTable.vue
@@ -9,6 +9,7 @@
     :filter="filterTable"
     :filter-method="filterFct"
     flat
+    class="scroller"
   >
     <template v-slot:body="props">
       <q-tr :props="props">
@@ -132,4 +133,21 @@ export default {
   },
 }
 </script>
-<style lang="stylus"></style>
+<style lang="stylus">
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+  
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+  
+  
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
+</style>

--- a/src/views/charts/tables/NetworkDelayTable.vue
+++ b/src/views/charts/tables/NetworkDelayTable.vue
@@ -133,21 +133,4 @@ export default {
   },
 }
 </script>
-<style lang="stylus">
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-  
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-  
-  
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
-</style>
+<style lang="stylus"></style>

--- a/src/views/charts/tables/PrefixHegemonyTable.vue
+++ b/src/views/charts/tables/PrefixHegemonyTable.vue
@@ -342,20 +342,4 @@ export default {
 .comma:not(:empty) ~ .comma:not(:empty):before
   content ", ";
 
-.scroller
-    max-height 350pt
-    overflow-y auto
-
-.scroller::-webkit-scrollbar
-    width: 9px;
-
-.scroller::-webkit-scrollbar-track
-    background: lightgrey
-    border: 4px solid transparent;
-    background-clip: content-box;  
-
-
-.scroller::-webkit-scrollbar-thumb
-    background: #c3c3c3;
-    border-radius 6pt
 </style>

--- a/src/views/charts/tables/PrefixHegemonyTable.vue
+++ b/src/views/charts/tables/PrefixHegemonyTable.vue
@@ -19,6 +19,7 @@
             separator="vertical"
             binary-state-sort
             flat
+            class="scroller"
         >
             <div slot="header" slot-scope="props" style="display: contents">
                 <q-tr>
@@ -340,4 +341,21 @@ export default {
 <style lang="stylus">
 .comma:not(:empty) ~ .comma:not(:empty):before
   content ", ";
+
+.scroller
+    max-height 350pt
+    overflow-y auto
+
+.scroller::-webkit-scrollbar
+    width: 9px;
+
+.scroller::-webkit-scrollbar-track
+    background: lightgrey
+    border: 4px solid transparent;
+    background-clip: content-box;  
+
+
+.scroller::-webkit-scrollbar-thumb
+    background: #c3c3c3;
+    border-radius 6pt
 </style>

--- a/src/views/charts/tables/PrefixHegemonyTableStats.vue
+++ b/src/views/charts/tables/PrefixHegemonyTableStats.vue
@@ -156,20 +156,4 @@ export default {
 .comma:not(:empty) ~ .comma:not(:empty):before
   content ", ";
 
-.scroller
-  max-height 350pt
-  overflow-y auto
-
-.scroller::-webkit-scrollbar
-  width: 9px;
-
-.scroller::-webkit-scrollbar-track
-  background: lightgrey
-  border: 4px solid transparent;
-  background-clip: content-box;  
-
-
-.scroller::-webkit-scrollbar-thumb
-  background: #c3c3c3;
-  border-radius 6pt
 </style>

--- a/src/views/charts/tables/PrefixHegemonyTableStats.vue
+++ b/src/views/charts/tables/PrefixHegemonyTableStats.vue
@@ -19,6 +19,7 @@
       separator="vertical"
       binary-state-sort
       flat
+      class="scroller"
     >
       <div slot="header" slot-scope="props" style="display: contents">
         <q-tr>
@@ -154,4 +155,21 @@ export default {
 
 .comma:not(:empty) ~ .comma:not(:empty):before
   content ", ";
+
+.scroller
+  max-height 350pt
+  overflow-y auto
+
+.scroller::-webkit-scrollbar
+  width: 9px;
+
+.scroller::-webkit-scrollbar-track
+  background: lightgrey
+  border: 4px solid transparent;
+  background-clip: content-box;  
+
+
+.scroller::-webkit-scrollbar-thumb
+  background: #c3c3c3;
+  border-radius 6pt
 </style>


### PR DESCRIPTION
Fixes #395 
I have added scrollbars to various tables where there are many records.
There are some tables with many records and a option to choose the number of records to be shown per page.
By default it is 5-10. But when a large number is chosen, then the records extend up to bottom of the page and this causes problem that the user has to scroll a lot to see some other section of the page.

The scrollbar appears only when the table height crosses a certain max-height, otherwise it is not visible.

For example:
When less records are there:
![image](https://user-images.githubusercontent.com/87076033/229271075-c6867a04-2269-4ce3-91ba-721a10e280ee.png)

When records per page is increased to 10:
![image](https://user-images.githubusercontent.com/87076033/229271104-beffc1e0-b9e8-4761-a89f-3b9520bd3268.png)

@romain-fontugne @Aniket762 Please review the changes and merge it.
Thank you.

