### PR TITLE
Fix#421 - Expansion panel not working properly inside country reports

### DIFF
--- a/src/views/Countries.vue
+++ b/src/views/Countries.vue
@@ -84,7 +84,6 @@
                 :clear="clear"
                 searchBar
                 ref="networkDelayChart"
-                @display="displayNetDelay"
               />
             </q-card-section>
           </q-card>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix #421 . The expansion panel is binded to `show.net_delay`. Also, `displayNetDelay` method is binded to the `display` event of the `network-delay-chart` component. But the problem is that the `network-delay-chart `component emits a `display` event with a `true` value always. So, whenever we try to shrink the panel, `show.net_delay` is updated to the `true' value of the `diaplay' event by the `displayNetDelay` function.
Now I removed the `diaplay` event from the `displayNetDelay` because it is not useful here. 




## Motivation and Context

To make the UI look better and work properly.

## How Has This Been Tested?

I have run and tested the functionality locally and it works as expected.

## Screenshots (if appropriate):
![Untitled design](https://user-images.githubusercontent.com/55330484/230711997-af8e1a7f-f7c4-4779-858f-2a1c699aa588.gif)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
