### PR TITLE
Fix: selecting current day in global reports page changes data to 01 January 1970

### DIFF
--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -62,6 +62,7 @@ export default {
       return selectDate >= this.min && selectDate <= this.max
     },
     propagate(event) {
+      if(event === null) return;
       let selectedDate = new Date(event)
       this.qTimeModel = selectedDate.toISOString()
       ;(this.selectedDateTime = this.$options.filters.ihrUtcString(selectedDate)), (this.show = false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On selecting the same date twice the page loaded data for the date 01 January 1970. this PR fixes this issue.
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #350 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I have testing the changes by running the website in the browser.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
https://user-images.githubusercontent.com/110781959/230958446-138b8843-9c3d-4ce2-8595-9ca40b5d19ea.mp4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
