### PR TITLE
Bugfix/mismatch loading timeseries

### DIFF
--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -86,8 +86,8 @@
       <q-card class="IHR_charts-body">
         <q-card-section>
           <aggregated-alarms-world-map :start-time="startTime" :end-time="endTime" :fetch="fetch"
-            :hegemonyAlarms="hegemonyAlarms" :networkDelayAlarms="networkDelayAlarms" :key="aggregatedAlarmsWorldMapKey"
-            ::min-deviation="minDeviationNetworkDelay" @loading="aggregatedAlarmsWorldMapLoading" :dateTimeFilter="dateTimeFilter"
+            :loading="loading.aggregatedAlarms" :hegemonyAlarms="hegemonyAlarms" :networkDelayAlarms="networkDelayAlarms" :key="aggregatedAlarmsWorldMapKey"
+            ::min-deviation="minDeviationNetworkDelay" @loading="loading.aggregatedAlarms = $event" :dateTimeFilter="dateTimeFilter"
             :resetTimeFlag="resetTimeFlag" :alarmTypesFilter="alarmTypesFilter"
             :alarmDataSourcesFilter="alarmDataSourcesFilter" @aggregated-alarms-data-loaded="aggregatedAlarms = $event"
             @country-click="countryClicked = $event" ref="aggregatedAlarmsWorldMap" />
@@ -95,7 +95,7 @@
       </q-card>
       <q-card class="IHR_charts-body">
         <q-card-section>
-          <aggregated-alarms-time-series :aggregatedAlarms="aggregatedAlarms" :key="aggregatedAlarmsTimeSeriesKey" @loading="aggregatedAlarmsTimeSeriesLoading"
+          <aggregated-alarms-time-series :aggregatedAlarms="aggregatedAlarms" :key="aggregatedAlarmsTimeSeriesKey" :loading="loading.aggregatedAlarms"
             :countryClicked="countryClicked" :resetGranularityFlag="resetGranularityFlag"
             @time-series-reset="countryClicked = ''" :alarmTypesFilter="alarmTypesFilter"
             :alarmDataSourcesFilter="alarmDataSourcesFilter" ref="aggregatedAlarmsTimeSeries" />
@@ -479,8 +479,7 @@ export default {
         networkDelay: true,
         linkDelay: true,
         disco: true,
-        aggregatedAlarmsWorldMapData: false,
-        aggregatedAlarmsTimeSeriesData: false,
+        aggregatedAlarms: true,
       },
       hegemonyAlarms: [],
       networkDelayAlarms: [],
@@ -515,16 +514,6 @@ export default {
     discoLoading(val) {
       this.$nextTick(function () {
         this.loading.disco = val
-      })
-    },
-    aggregatedAlarmsWorldMapLoading(val) {
-      this.$nextTick(function () {
-        this.loading.aggregatedAlarmsWorldMapData = val
-      })
-    },
-    aggregatedAlarmsTimeSeriesLoading(val) {
-      this.$nextTick(function () {
-        this.loading.aggregatedAlarmsTimeSeriesData = val
       })
     },
     pushRoute() {

--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -54,6 +54,42 @@
       </q-card-section>
       <q-separator />
     </q-card>
+    <q-expansion-item caption="IHR Aggregated Alarms" header-class="IHR_charts-title" default-opened expand-icon-toggle
+      v-model="aggregatedAlarmsExpanded">
+      <template v-slot:header>
+        <div class="graph-header-div">
+          <q-item-section class="graph-header">
+            <q-item-section avatar>
+              <q-icon name="fas fa-plug" color="primary" text-color="white" />
+            </q-item-section>
+
+            <q-item-section>
+              <a id="aggregatedAlarms"></a>
+              <div class="text-primary">
+                {{ $t('charts.aggregatedAlarms.title') }}
+              </div>
+              <div class="text-caption text-grey">IHR Aggregated Alarms</div>
+            </q-item-section>
+          </q-item-section>
+        </div>
+      </template>
+
+      <q-card class="IHR_charts-body">
+        <q-card-section>
+          <aggregated-alarms-world-map :start-time="startTime" :end-time="endTime" :fetch="fetch"
+            :hegemonyAlarms="hegemonyAlarms" :networkDelayAlarms="networkDelayAlarms" :key="aggregatedAlarmsWorldMapKey"
+            ::min-deviation="minDeviationNetworkDelay" @loading="aggregatedAlarmsLoading"
+            @aggregated-alarms-data-loaded="aggregatedAlarms = $event" @country-click="countryClicked = $event"
+            ref="aggregatedAlarmsWorldMap" />
+        </q-card-section>
+      </q-card>
+      <q-card class="IHR_charts-body">
+        <q-card-section>
+          <aggregated-alarms-time-series :aggregatedAlarms="aggregatedAlarms" :key="aggregatedAlarmsTimeSeriesKey"
+            :countryClicked="countryClicked" @time-series-reset="countryClicked = ''" ref="aggregatedAlarmsTimeSeries" />
+        </q-card-section>
+      </q-card>
+    </q-expansion-item>
     <div v-show="!this.nbAlarms['hegemony']">
       <q-expansion-item header-class="IHR_charts-title" default-opened expand-icon-toggle v-model="ndelayExpanded">
         <template v-slot:header>
@@ -323,42 +359,6 @@
       </q-card>
     </q-expansion-item>
     <!-- </div> -->
-    <q-expansion-item caption="IHR Aggregated Alarms" header-class="IHR_charts-title" default-opened expand-icon-toggle
-      v-model="aggregatedAlarmsExpanded">
-      <template v-slot:header>
-        <div class="graph-header-div">
-          <q-item-section class="graph-header">
-            <q-item-section avatar>
-              <q-icon name="fas fa-plug" color="primary" text-color="white" />
-            </q-item-section>
-
-            <q-item-section>
-              <a id="aggregatedAlarms"></a>
-              <div class="text-primary">
-                {{ $t('charts.aggregatedAlarms.title') }}
-              </div>
-              <div class="text-caption text-grey">IHR Aggregated Alarms</div>
-            </q-item-section>
-          </q-item-section>
-        </div>
-      </template>
-
-      <q-card class="IHR_charts-body">
-        <q-card-section>
-          <aggregated-alarms-world-map :start-time="startTime" :end-time="endTime" :fetch="fetch"
-            :hegemonyAlarms="hegemonyAlarms" :networkDelayAlarms="networkDelayAlarms" :key="aggregatedAlarmsWorldMapKey"
-            ::min-deviation="minDeviationNetworkDelay" @loading="aggregatedAlarmsLoading"
-            @aggregated-alarms-data-loaded="aggregatedAlarms = $event" @country-click="countryClicked = $event"
-            ref="aggregatedAlarmsWorldMap" />
-        </q-card-section>
-      </q-card>
-      <q-card class="IHR_charts-body">
-        <q-card-section>
-          <aggregated-alarms-time-series :aggregatedAlarms="aggregatedAlarms" :key="aggregatedAlarmsTimeSeriesKey"
-            :countryClicked="countryClicked" @time-series-reset="countryClicked = ''" ref="aggregatedAlarmsTimeSeries" />
-        </q-card-section>
-      </q-card>
-    </q-expansion-item>
   </div>
 </template>
 

--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -74,19 +74,31 @@
         </div>
       </template>
 
-      <q-card class="IHR_charts-body">
+      <q-card>
         <q-card-section>
-          <aggregated-alarms-world-map :start-time="startTime" :end-time="endTime" :fetch="fetch"
-            :hegemonyAlarms="hegemonyAlarms" :networkDelayAlarms="networkDelayAlarms" :key="aggregatedAlarmsWorldMapKey"
-            ::min-deviation="minDeviationNetworkDelay" @loading="aggregatedAlarmsLoading"
-            @aggregated-alarms-data-loaded="aggregatedAlarms = $event" @country-click="countryClicked = $event"
-            ref="aggregatedAlarmsWorldMap" />
+          <aggregated-alarm-filters-overview :start-time="startTime" :end-time="endTime" :alarms="aggregatedAlarms"
+            @filter-alarms-by-time="dateTimeFilter = $event" @reset-time="resetTimeFlag = !resetTimeFlag"
+            @reset-granularity="resetGranularityFlag = !resetGranularityFlag"
+            @filter-alarms-by-alarm-types="alarmTypesFilter = $event"
+            @filter-alarms-by-data-sources="alarmDataSourcesFilter = $event" />
         </q-card-section>
       </q-card>
       <q-card class="IHR_charts-body">
         <q-card-section>
-          <aggregated-alarms-time-series :aggregatedAlarms="aggregatedAlarms" :key="aggregatedAlarmsTimeSeriesKey"
-            :countryClicked="countryClicked" @time-series-reset="countryClicked = ''" ref="aggregatedAlarmsTimeSeries" />
+          <aggregated-alarms-world-map :start-time="startTime" :end-time="endTime" :fetch="fetch"
+            :hegemonyAlarms="hegemonyAlarms" :networkDelayAlarms="networkDelayAlarms" :key="aggregatedAlarmsWorldMapKey"
+            ::min-deviation="minDeviationNetworkDelay" @loading="aggregatedAlarmsWorldMapLoading" :dateTimeFilter="dateTimeFilter"
+            :resetTimeFlag="resetTimeFlag" :alarmTypesFilter="alarmTypesFilter"
+            :alarmDataSourcesFilter="alarmDataSourcesFilter" @aggregated-alarms-data-loaded="aggregatedAlarms = $event"
+            @country-click="countryClicked = $event" ref="aggregatedAlarmsWorldMap" />
+        </q-card-section>
+      </q-card>
+      <q-card class="IHR_charts-body">
+        <q-card-section>
+          <aggregated-alarms-time-series :aggregatedAlarms="aggregatedAlarms" :key="aggregatedAlarmsTimeSeriesKey" @loading="aggregatedAlarmsTimeSeriesLoading"
+            :countryClicked="countryClicked" :resetGranularityFlag="resetGranularityFlag"
+            @time-series-reset="countryClicked = ''" :alarmTypesFilter="alarmTypesFilter"
+            :alarmDataSourcesFilter="alarmDataSourcesFilter" ref="aggregatedAlarmsTimeSeries" />
         </q-card-section>
       </q-card>
     </q-expansion-item>
@@ -367,6 +379,7 @@ import reportMixin from '@/views/mixin/reportMixin'
 import DiscoChart, { DEFAULT_DISCO_AVG_LEVEL } from './charts/global/DiscoChart'
 import NetworkDelayAlarmsChart from './charts/global/NetworkDelayAlarmsChart'
 import HegemonyAlarmsChart from './charts/global/HegemonyAlarmsChart'
+import AggregatedAlarmFiltersOverview from './charts/global/AggregatedAlarmFiltersOverview.vue'
 import AggregatedAlarmsWorldMap from './charts/global/AggregatedAlarmsWorldMap'
 import AggregatedAlarmsTimeSeries from './charts/global/AggregatedAlarmsTimeSeries'
 import DelayChart, {
@@ -414,6 +427,7 @@ export default {
     NetworkDelayAlarmsChart,
     HegemonyAlarmsChart,
     DiscoChart,
+    AggregatedAlarmFiltersOverview,
     AggregatedAlarmsWorldMap,
     AggregatedAlarmsTimeSeries,
     DelayChart,
@@ -465,12 +479,18 @@ export default {
         networkDelay: true,
         linkDelay: true,
         disco: true,
-        aggregatedData: true,
+        aggregatedAlarmsWorldMapData: false,
+        aggregatedAlarmsTimeSeriesData: false,
       },
       hegemonyAlarms: [],
       networkDelayAlarms: [],
       aggregatedAlarms: [],
-      countryClicked: null
+      countryClicked: null,
+      dateTimeFilter: null,
+      resetTimeFlag: false,
+      resetGranularityFlag: false,
+      alarmTypesFilter: {},
+      alarmDataSourcesFilter: {}
     }
   },
   mounted() {
@@ -497,9 +517,14 @@ export default {
         this.loading.disco = val
       })
     },
-    aggregatedAlarmsLoading(val) {
+    aggregatedAlarmsWorldMapLoading(val) {
       this.$nextTick(function () {
-        this.loading.aggregatedData = val
+        this.loading.aggregatedAlarmsWorldMapData = val
+      })
+    },
+    aggregatedAlarmsTimeSeriesLoading(val) {
+      this.$nextTick(function () {
+        this.loading.aggregatedAlarmsTimeSeriesData = val
       })
     },
     pushRoute() {
@@ -561,6 +586,8 @@ export default {
       html2pdf(element, opt)
       console.log('button is clicked')
     },
+
+
   },
   computed: {
     title() {

--- a/src/views/charts/global/AggregatedAlarmFiltersOverview.vue
+++ b/src/views/charts/global/AggregatedAlarmFiltersOverview.vue
@@ -111,8 +111,8 @@ export default {
                 { value: "edges", label: "Edges", showModal: false },
             ],
             dataSources: [
+                { value: "ihr", label: "IHR", showModal: false },
                 { value: "grip", label: "GRIP", showModal: false },
-                { value: "source2", label: "Data Source 2", showModal: false },
                 { value: "source3", label: "Data Source 3", showModal: false },
                 { value: "source4", label: "Data Source 4", showModal: false },
                 { value: "source5", label: "Data Source 5", showModal: false },
@@ -126,30 +126,55 @@ export default {
         }
     },
     created() {
-        this.alarmTypes.forEach((alarm) => {
-            this.$set(this.selectedAlarmTypes, alarm.value, false);
-        });
-
-        this.dataSources.forEach((dataSource) => {
-            this.$set(this.selectedDataSources, dataSource.value, false);
-        });
+        this.$set(this.selectedDataSources, 'ihr', true);
     },
     watch: {
         selectedAlarmTypes: {
             handler: function (newSelectedAlarmTypes) {
-                this.$emit('filter-alarms-by-alarm-types', newSelectedAlarmTypes);
+                if (!newSelectedAlarmTypes.hegemony && !newSelectedAlarmTypes.network_delay) {
+                    this.$set(this.selectedDataSources, 'ihr', false);
+                } else {
+                    this.$set(this.selectedDataSources, 'ihr', true);
+                }
+
+                if (!newSelectedAlarmTypes.moas && !newSelectedAlarmTypes.submoas && !newSelectedAlarmTypes.defcon && !newSelectedAlarmTypes.edges) {
+                    this.$set(this.selectedDataSources, 'grip', false);
+                } else {
+                    this.$set(this.selectedDataSources, 'grip', true);
+                }
+                this.$emit('filter-alarms-by-alarm-types', newSelectedAlarmTypes)
             },
-            deep: true,
+            deep: true
         },
         selectedDataSources: {
             handler: function (newSelectedDataSources) {
-                let includeCheckedDataSources = Object.values(newSelectedDataSources).includes(true);
-                if (includeCheckedDataSources) {
-                    this.$emit('filter-alarms-by-data-sources', newSelectedDataSources);
+                if (newSelectedDataSources.ihr) {
+                    if (!this.selectedAlarmTypes.hegemony && !this.selectedAlarmTypes.network_delay) {
+                        this.$set(this.selectedAlarmTypes, 'hegemony', true);
+                        this.$set(this.selectedAlarmTypes, 'network_delay', true);
+                    }
+                } else {
+                    this.$set(this.selectedAlarmTypes, 'hegemony', false);
+                    this.$set(this.selectedAlarmTypes, 'network_delay', false);
                 }
+
+                if (newSelectedDataSources.grip) {
+                    if (!this.selectedAlarmTypes.moas && !this.selectedAlarmTypes.submoas && !this.selectedAlarmTypes.defcon && !this.selectedAlarmTypes.edges) {
+                        this.$set(this.selectedAlarmTypes, 'moas', true);
+                        this.$set(this.selectedAlarmTypes, 'submoas', true);
+                        this.$set(this.selectedAlarmTypes, 'defcon', true);
+                        this.$set(this.selectedAlarmTypes, 'edges', true);
+                    }
+                } else {
+                    this.$set(this.selectedAlarmTypes, 'moas', false);
+                    this.$set(this.selectedAlarmTypes, 'submoas', false);
+                    this.$set(this.selectedAlarmTypes, 'defcon', false);
+                    this.$set(this.selectedAlarmTypes, 'edges', false);
+                }
+                this.$emit('filter-alarms-by-data-sources', newSelectedDataSources);
             },
-            deep: true,
-        }
+            deep: true
+        },
     },
     methods: {
         toggleHelpModal(index) {

--- a/src/views/charts/global/AggregatedAlarmFiltersOverview.vue
+++ b/src/views/charts/global/AggregatedAlarmFiltersOverview.vue
@@ -1,0 +1,392 @@
+<template>
+    <div class="container">
+        <div class="alarm-types">
+            <h3 class="filter__category-title">Alarm Types:</h3>
+            <label v-for="(alarm, index) in alarmTypes" :key="index">
+                <div class="searchbar__heading-container">
+                    <input type="checkbox" :name="alarm.value" :value="alarm.value"
+                        v-model="selectedAlarmTypes[alarm.value]">
+                    <span class="label__input">{{ alarm.label }}</span>
+                    <div class="help">
+                        <button class="help__button" @click="toggleHelpModal(index)">?</button>
+                        <div class="help__modal" v-show="alarm.showModal">
+                            <div class="help__modal-content">
+                                <div class="help__title">Search</div>
+                                <div class="help__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. In aliquet
+                                    ligula ultricies libero imperdiet, at pharetra mi molestie. Fusce mollis ut mauris non
+                                    pretium. Integer varius tellus id metus bibendum.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </label>
+            <div class="button-container">
+                <button class="select-all-btn" type="button" @click="selectAllAlarmTypes">Select All</button>
+                <button class="unselect-all-btn" type="button" @click="unselectAllAlarmTypes">Unselect All</button>
+            </div>
+
+        </div>
+
+        <div class="data-sources">
+            <h3 class="filter__category-title">Data Sources:</h3>
+            <label v-for="(dataSource, index) in dataSources" :key="index">
+                <div class="searchbar__heading-container">
+                    <input type="checkbox" :name="dataSource.value" :value="dataSource.value"
+                        v-model="selectedDataSources[dataSource.value]">
+                    <span class="label__input">{{ dataSource.label }}</span>
+                    <div class="help">
+                        <button class="help__button" @click="toggleHelpModal(index)">?</button>
+                        <div class="help__modal" v-show="dataSource.showModal">
+                            <div class="help__modal-content">
+                                <div class="help__title">Search</div>
+                                <div class="help__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. In aliquet
+                                    ligula ultricies libero imperdiet, at pharetra mi molestie. Fusce mollis ut mauris non
+                                    pretium. Integer varius tellus id metus bibendum.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </label>
+            <div class="button-container">
+                <button class="select-all-btn" type="button" @click="selectAllDataSources">Select All</button>
+                <button class="unselect-all-btn" type="button" @click="unselectAllDataSources">Unselect All</button>
+            </div>
+
+        </div>
+
+        <div class="flex-container">
+            <div class="datetime-filter">
+                <h3 class="filter__category-title">Date Time Filter:</h3>
+                <div class="datetime-picker">
+                    <label for="start-datetime">Start DateTime:</label>
+                    <input type="datetime-local" id="start-datetime" v-model="startDateTime" :min="minStartDateTime"
+                        :max="maxEndDateTime">
+                </div>
+                <div class="datetime-picker">
+                    <label for="end-datetime">End DateTime:</label>
+                    <input type="datetime-local" id="end-datetime" v-model="endDateTime" :min="minStartDateTime"
+                        :max="maxEndDateTime">
+                </div>
+                <button @click="filterAlarmsByTime" id="apply-btn" type="button">Apply</button>
+                <button @click="resetTime" id="reset-time-btn" type="button">Reset Time</button>
+            </div>
+
+            <div class="reset-granularity">
+                <h3 class="filter__category-title">Reset Granularity:</h3>
+                <button @click="resetGranularity" id="reset-granularity-btn" type="button">Reset Granularity</button>
+            </div>
+        </div>
+
+
+
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        alarms: {
+            type: Array,
+            required: true,
+        },
+        startTime: {
+            type: Date,
+            required: true,
+        },
+        endTime: {
+            type: Date,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            alarmTypes: [
+                { value: "hegemony", label: "Hegemony", showModal: false },
+                { value: "network_delay", label: "Network Delay", showModal: false },
+                { value: "moas", label: "MOAS", showModal: false },
+                { value: "submoas", label: "SubMOAS", showModal: false },
+                { value: "defcon", label: "Defcon", showModal: false },
+                { value: "edges", label: "Edges", showModal: false },
+            ],
+            dataSources: [
+                { value: "grip", label: "GRIP", showModal: false },
+                { value: "source2", label: "Data Source 2", showModal: false },
+                { value: "source3", label: "Data Source 3", showModal: false },
+                { value: "source4", label: "Data Source 4", showModal: false },
+                { value: "source5", label: "Data Source 5", showModal: false },
+            ],
+            selectedAlarmTypes: {},
+            selectedDataSources: {},
+            startDateTime: this.formatTime(this.startTime),
+            endDateTime: this.formatTime(this.endTime),
+            minStartDateTime: this.formatTime(this.startTime),
+            maxEndDateTime: this.formatTime(this.endTime),
+        }
+    },
+    created() {
+        this.alarmTypes.forEach((alarm) => {
+            this.$set(this.selectedAlarmTypes, alarm.value, false);
+        });
+
+        this.dataSources.forEach((dataSource) => {
+            this.$set(this.selectedDataSources, dataSource.value, false);
+        });
+    },
+    watch: {
+        selectedAlarmTypes: {
+            handler: function (newSelectedAlarmTypes) {
+                this.$emit('filter-alarms-by-alarm-types', newSelectedAlarmTypes);
+            },
+            deep: true,
+        },
+        selectedDataSources: {
+            handler: function (newSelectedDataSources) {
+                let includeCheckedDataSources = Object.values(newSelectedDataSources).includes(true);
+                if (includeCheckedDataSources) {
+                    this.$emit('filter-alarms-by-data-sources', newSelectedDataSources);
+                }
+            },
+            deep: true,
+        }
+    },
+    methods: {
+        toggleHelpModal(index) {
+            this.alarmTypes[index].showModal = !this.alarmTypes[index].showModal;
+        },
+
+        formatTime(date) {
+            const year = date.getUTCFullYear();
+            const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+            const day = String(date.getUTCDate()).padStart(2, '0');
+            const hours = String(date.getUTCHours()).padStart(2, '0');
+            const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+            const formattedDate = `${year}-${month}-${day}T${hours}:${minutes}`;
+            return formattedDate;
+        },
+
+        filterAlarmsByTime() {
+            if (this.alarms && this.alarms.length && this.startDateTime && this.endDateTime) {
+                let startDateTime = new Date(this.startDateTime);
+                let endDateTime = new Date(this.endDateTime);
+                if (startDateTime > endDateTime) {
+                    alert('Start Date cannot be greater than End Date')
+                    return
+                }
+                const formattedStartDateTime = startDateTime.toISOString().slice(0, 16);
+                const formattedEndDateTime = endDateTime.toISOString().slice(0, 16);
+                startDateTime = new Date(formattedStartDateTime);
+                endDateTime = new Date(formattedEndDateTime);
+                const dateTimeFilter = { startDateTime, endDateTime };
+                this.$emit('filter-alarms-by-time', dateTimeFilter);
+            }
+        },
+
+        resetTime() {
+            this.$emit('reset-time');
+        },
+
+        resetGranularity() {
+            this.$emit('reset-granularity');
+        },
+
+        selectAllAlarmTypes() {
+            for (const alarmType of this.alarmTypes) {
+                this.$set(this.selectedAlarmTypes, alarmType.value, true);
+            }
+        },
+
+        unselectAllAlarmTypes() {
+            for (const alarmType of this.alarmTypes) {
+                this.$set(this.selectedAlarmTypes, alarmType.value, false);
+            }
+        },
+
+        selectAllDataSources() {
+            for (const dataSource of this.dataSources) {
+                this.$set(this.selectedDataSources, dataSource.value, true);
+            }
+
+        },
+
+        unselectAllDataSources() {
+            for (const dataSource of this.dataSources) {
+                this.$set(this.selectedDataSources, dataSource.value, false);
+            }
+        }
+
+    }
+}
+</script>
+
+<style scoped>
+.container {
+    background-color: #f2f2f2;
+    border-radius: 10px;
+    padding: 2px 20px 20px 20px;
+    color: #283237;
+}
+
+.flex-container {
+    display: flex;
+}
+
+.datetime-filter,
+.reset-granularity {
+    flex: 1;
+}
+
+.label__input {
+    margin: 2px;
+}
+
+.alarm-types,
+.datetime-filter,
+.data-sources,
+.reset-granularity {
+    color: #283237;
+}
+
+input[type="checkbox"],
+input[type="datetime-local"],
+button {
+    color: #283237;
+}
+
+.data-sources ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+.data-sources li {
+    margin-bottom: 5px;
+}
+
+.select-all,
+.unselect-all {
+    margin-top: 10px;
+}
+
+.heading-h1 {
+    color: #283237;
+    font-size: 2rem;
+}
+
+.help {
+    margin: 3px;
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.help__button {
+    background: linear-gradient(2deg, #1a5dae, #598dcc, #1a5dae, #598dcc);
+    color: #fff;
+    font-weight: 700;
+    cursor: pointer;
+    text-align: center;
+    border: none;
+    background-size: 100% 300%;
+    transition: all .4s ease-in-out;
+    position: relative;
+    z-index: 10;
+    box-shadow: inset 0 0.2rem 0.1rem hsla(0, 0%, 100%, .2), inset 0 0 0 0.1rem rgba(0, 0, 0, .15), 0 0.1rem 0 hsla(0, 0%, 100%, .15);
+    border-radius: 3rem;
+    font-size: 0.7rem;
+    height: 0.8rem;
+    width: 0.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.help__text,
+.help__title {
+    padding: 0.5rem 1.5rem;
+}
+
+.help__title {
+    background-color: #f7f7f7;
+    text-align: left;
+    border-bottom: 0.1rem solid #ebebeb;
+    border-top-right-radius: 0.3rem;
+    border-top-left-radius: 0.3rem;
+}
+
+.help__modal {
+    position: absolute;
+    z-index: 9999;
+    background: #fff;
+    border-radius: 0.3rem;
+    box-shadow: 0 1px 2px #9f9d9d;
+    flex-direction: column;
+    width: 16rem;
+    font-size: 0.6rem;
+    color: #2c3e50;
+    border: 0.1rem solid #b3b3b3;
+    left: 3rem;
+    top: 0;
+}
+
+.help__modal-content {
+    position: relative;
+    z-index: 10002;
+}
+
+.tooltip {
+    position: absolute;
+    background-color: #fff;
+    padding: px;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 9999;
+    font-size: 0.8rem;
+}
+
+.searchbar__heading-container {
+    display: inline-flex;
+    align-items: center;
+    margin: 3px 3px 3px 3px;
+}
+
+.searchbar__heading-container label {
+    margin-right: 10px;
+}
+
+label {
+    display: inline-block;
+}
+
+.filter__category-title {
+    display: block;
+    font-size: 1.17em;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+}
+
+.button-container {
+    margin: 3px 3px 3px 3px;
+}
+
+#apply-btn,
+#reset-time-btn,
+.unselect-all-btn {
+    margin: 3px;
+}
+
+.datetime-picker {
+    margin: 7px;
+}
+
+#start-datetime {
+    margin-left: 6px;
+}
+
+#end-datetime {
+    margin-left: 12px;
+}
+</style>

--- a/src/views/charts/global/AggregatedAlarmsTimeSeries.vue
+++ b/src/views/charts/global/AggregatedAlarmsTimeSeries.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="IHR_chart">
-        <aggregated-alarms-time-series-reactive :chart="chart" :loading="loading" />
+        <aggregated-alarms-time-series-reactive :chart="chart" :aggregatedAlarms="aggregatedAlarms" :loading="loading" />
     </div>
 </template>
     
@@ -17,7 +17,7 @@ export default {
     props: {
         aggregatedAlarms: {
             type: Array,
-            required: true,
+            required: false,
             default: () => []
         },
         countryClicked: {
@@ -44,7 +44,10 @@ export default {
             required: false,
             default: () => { }
         },
-
+        loading: {
+            type: Boolean,
+            required: true,
+        }
     },
     emits: {
         'time-series-reset': function () {
@@ -58,20 +61,7 @@ export default {
                     this.resetTimeSeries()
                 }
             }
-        },
-        alarmDataSourcesFilter: {
-            handler: function (newAlarmDataSourcesFilter) {
-                if (newAlarmDataSourcesFilter.grip) {
-                    this.loading = true
-                }
-
-                if (!Object.values(newAlarmDataSourcesFilter).includes(true)) {
-                    this.chart.traces = []
-                    this.loading = false
-                }
-            },
-            deep: true
-        },
+        }
     },
     data() {
         const chartLayout = {
@@ -114,7 +104,6 @@ export default {
     },
     methods: {
         initTimeSeries() {
-            this.loading = true
             if (this.aggregatedAlarms.length) {
                 let groupedAlarms, legendName;
 
@@ -133,7 +122,6 @@ export default {
                 this.sortAlarmsByCountry(groupedAlarms)
                 const customHoverData = this.getCustomHoverData(groupedAlarms)
                 this.drawChart(groupedAlarms, customHoverData, legendName);
-                this.loading = false
             }
         },
         resetTimeSeries() {

--- a/src/views/charts/global/AggregatedAlarmsTimeSeries.vue
+++ b/src/views/charts/global/AggregatedAlarmsTimeSeries.vue
@@ -1,10 +1,6 @@
-f<template>
+<template>
     <div class="IHR_chart">
-        <div>
-            <button @click="resetTimeSeries">Reset</button>
-            <aggregated-alarms-time-series-reactive :chart="chart" :loading="loading" />
-        </div>
-
+        <aggregated-alarms-time-series-reactive :chart="chart" :loading="loading" />
     </div>
 </template>
     
@@ -27,11 +23,50 @@ export default {
         countryClicked: {
             type: String,
             required: false,
-        }
+        },
+        resetGranularityFlag: {
+            type: Boolean,
+            required: false,
+            default: false
+        },
+        alarmTypesFilter: {
+            type: Object,
+            required: false,
+            default: () => {
+                return {
+                    hegemony: true,
+                    network_delay: true,
+                }
+            }
+        },
+        alarmDataSourcesFilter: {
+            type: Object,
+            required: false,
+            default: () => { }
+        },
+
     },
     emits: {
         'time-series-reset': function () {
             return false
+        },
+    },
+    watch: {
+        resetGranularityFlag: {
+            handler: function (newResetGranularityFlag) {
+                if (newResetGranularityFlag) {
+                    this.resetTimeSeries()
+                }
+            }
+        },
+        alarmDataSourcesFilter: {
+            handler: function (newAlarmDataSourcesFilter) {
+                // let checkedValuesIncluded = Object.values(newAlarmDataSourcesFilter).includes(true)
+                if (newAlarmDataSourcesFilter.grip) {
+                    this.loading = true
+                }
+            },
+            deep: true
         },
     },
     data() {
@@ -59,6 +94,21 @@ export default {
         }
     },
 
+    computed: {
+        alarmTypes() {
+            let alarmTypes = ['hegemony', 'network_delay']
+            if (this.alarmDataSourcesFilter.grip) {
+                alarmTypes = [
+                    ...alarmTypes,
+                    'moas',
+                    'submoas',
+                    'defcon',
+                    'edges'
+                ]
+            }
+            return alarmTypes
+        }
+    },
     mounted() {
         this.loading = true
         if (this.aggregatedAlarms.length) {
@@ -73,7 +123,7 @@ export default {
                 legendName = 'country_name'
             }
 
-            this.processAlarmCategories(groupedAlarms)
+            this.processAlarmTypes(groupedAlarms, this.alarmTypes)
             this.addTotalAlarmCountsRecord(groupedAlarms)
             this.processAggregatedAlarm(groupedAlarms)
             this.sortAlarmsByCountry(groupedAlarms)
@@ -113,34 +163,43 @@ export default {
                 if (existingEntry) {
                     existingEntry.hegemony_alarm_counts = existingEntry.hegemony_alarm_counts.concat(obj.hegemony_alarm_counts)
                     existingEntry.network_delay_alarm_counts = existingEntry.network_delay_alarm_counts.concat(obj.network_delay_alarm_counts)
-                    existingEntry.defcon_alarm_counts = existingEntry.defcon_alarm_counts.concat(obj.defcon_alarm_counts)
-                    existingEntry.edges_alarm_counts = existingEntry.edges_alarm_counts.concat(obj.edges_alarm_counts)
-                    existingEntry.moas_alarm_counts = existingEntry.moas_alarm_counts.concat(obj.moas_alarm_counts)
-                    existingEntry.submoas_alarm_counts = existingEntry.submoas_alarm_counts.concat(obj.submoas_alarm_counts)
                     existingEntry.hegemony_alarm_timebins = existingEntry.hegemony_alarm_timebins.concat(obj.hegemony_alarm_timebins)
                     existingEntry.network_delay_alarm_timebins = existingEntry.network_delay_alarm_timebins.concat(obj.network_delay_alarm_timebins)
-                    existingEntry.defcon_alarm_timebins = existingEntry.defcon_alarm_timebins.concat(obj.defcon_alarm_timebins)
-                    existingEntry.edges_alarm_timebins = existingEntry.edges_alarm_timebins.concat(obj.edges_alarm_timebins)
-                    existingEntry.moas_alarm_timebins = existingEntry.moas_alarm_timebins.concat(obj.moas_alarm_timebins)
-                    existingEntry.submoas_alarm_timebins = existingEntry.submoas_alarm_timebins.concat(obj.submoas_alarm_timebins)
+
+                    if (this.alarmDataSourcesFilter.grip) {
+                        existingEntry.moas_alarm_counts = existingEntry.moas_alarm_counts.concat(obj.moas_alarm_counts)
+                        existingEntry.submoas_alarm_counts = existingEntry.submoas_alarm_counts.concat(obj.submoas_alarm_counts)
+                        existingEntry.defcon_alarm_counts = existingEntry.defcon_alarm_counts.concat(obj.defcon_alarm_counts)
+                        existingEntry.edges_alarm_counts = existingEntry.edges_alarm_counts.concat(obj.edges_alarm_counts)
+                        existingEntry.moas_alarm_timebins = existingEntry.moas_alarm_timebins.concat(obj.moas_alarm_timebins)
+                        existingEntry.submoas_alarm_timebins = existingEntry.submoas_alarm_timebins.concat(obj.submoas_alarm_timebins)
+                        existingEntry.defcon_alarm_timebins = existingEntry.defcon_alarm_timebins.concat(obj.defcon_alarm_timebins)
+                        existingEntry.edges_alarm_timebins = existingEntry.edges_alarm_timebins.concat(obj.edges_alarm_timebins)
+                    }
                 } else {
-                    result.push({
+                    let alarmsByCountryInitial = {
                         country_iso_code2: obj.country_iso_code2,
                         country_iso_code3: obj.country_iso_code3,
                         country_name: obj.country_name,
                         hegemony_alarm_counts: obj.hegemony_alarm_counts,
                         network_delay_alarm_counts: obj.network_delay_alarm_counts,
-                        defcon_alarm_counts: obj.defcon_alarm_counts,
-                        edges_alarm_counts: obj.edges_alarm_counts,
-                        moas_alarm_counts: obj.moas_alarm_counts,
-                        submoas_alarm_counts: obj.submoas_alarm_counts,
                         hegemony_alarm_timebins: obj.hegemony_alarm_timebins,
                         network_delay_alarm_timebins: obj.network_delay_alarm_timebins,
-                        defcon_alarm_timebins: obj.defcon_alarm_timebins,
-                        edges_alarm_timebins: obj.edges_alarm_timebins,
-                        moas_alarm_timebins: obj.moas_alarm_timebins,
-                        submoas_alarm_timebins: obj.submoas_alarm_timebins,
-                    });
+                    }
+                    if (this.alarmDataSourcesFilter.grip) {
+                        alarmsByCountryInitial = {
+                            ...alarmsByCountryInitial,
+                            moas_alarm_counts: obj.moas_alarm_counts,
+                            submoas_alarm_counts: obj.submoas_alarm_counts,
+                            defcon_alarm_counts: obj.defcon_alarm_counts,
+                            edges_alarm_counts: obj.edges_alarm_counts,
+                            moas_alarm_timebins: obj.moas_alarm_timebins,
+                            submoas_alarm_timebins: obj.submoas_alarm_timebins,
+                            defcon_alarm_timebins: obj.defcon_alarm_timebins,
+                            edges_alarm_timebins: obj.edges_alarm_timebins,
+                        }
+                    }
+                    result.push(alarmsByCountryInitial);
                 }
 
                 return result;
@@ -155,35 +214,44 @@ export default {
                 if (existingEntry) {
                     existingEntry.hegemony_alarm_counts = existingEntry.hegemony_alarm_counts.concat(obj.hegemony_alarm_counts)
                     existingEntry.network_delay_alarm_counts = existingEntry.network_delay_alarm_counts.concat(obj.network_delay_alarm_counts)
-                    existingEntry.defcon_alarm_counts = existingEntry.defcon_alarm_counts.concat(obj.defcon_alarm_counts)
-                    existingEntry.edges_alarm_counts = existingEntry.edges_alarm_counts.concat(obj.edges_alarm_counts)
-                    existingEntry.moas_alarm_counts = existingEntry.moas_alarm_counts.concat(obj.moas_alarm_counts)
-                    existingEntry.submoas_alarm_counts = existingEntry.submoas_alarm_counts.concat(obj.submoas_alarm_counts)
                     existingEntry.hegemony_alarm_timebins = existingEntry.hegemony_alarm_timebins.concat(obj.hegemony_alarm_timebins)
                     existingEntry.network_delay_alarm_timebins = existingEntry.network_delay_alarm_timebins.concat(obj.network_delay_alarm_timebins)
-                    existingEntry.defcon_alarm_timebins = existingEntry.defcon_alarm_timebins.concat(obj.defcon_alarm_timebins)
-                    existingEntry.edges_alarm_timebins = existingEntry.edges_alarm_timebins.concat(obj.edges_alarm_timebins)
-                    existingEntry.moas_alarm_timebins = existingEntry.moas_alarm_timebins.concat(obj.moas_alarm_timebins)
-                    existingEntry.submoas_alarm_timebins = existingEntry.submoas_alarm_timebins.concat(obj.submoas_alarm_timebins)
+                    if (this.alarmDataSourcesFilter.grip) {
+                        existingEntry.moas_alarm_counts = existingEntry.moas_alarm_counts.concat(obj.moas_alarm_counts)
+                        existingEntry.submoas_alarm_counts = existingEntry.submoas_alarm_counts.concat(obj.submoas_alarm_counts)
+                        existingEntry.defcon_alarm_counts = existingEntry.defcon_alarm_counts.concat(obj.defcon_alarm_counts)
+                        existingEntry.edges_alarm_counts = existingEntry.edges_alarm_counts.concat(obj.edges_alarm_counts)
+                        existingEntry.moas_alarm_timebins = existingEntry.moas_alarm_timebins.concat(obj.moas_alarm_timebins)
+                        existingEntry.submoas_alarm_timebins = existingEntry.submoas_alarm_timebins.concat(obj.submoas_alarm_timebins)
+                        existingEntry.defcon_alarm_timebins = existingEntry.defcon_alarm_timebins.concat(obj.defcon_alarm_timebins)
+                        existingEntry.edges_alarm_timebins = existingEntry.edges_alarm_timebins.concat(obj.edges_alarm_timebins)
+                    }
                 } else {
-                    result.push({
+                    let alarmsByASNNumberInitial = {
                         asn_name: obj.asn_name,
                         country_iso_code2: obj.country_iso_code2,
                         country_iso_code3: obj.country_iso_code3,
                         country_name: obj.country_name,
                         hegemony_alarm_counts: obj.hegemony_alarm_counts,
                         network_delay_alarm_counts: obj.network_delay_alarm_counts,
-                        defcon_alarm_counts: obj.defcon_alarm_counts,
-                        edges_alarm_counts: obj.edges_alarm_counts,
-                        moas_alarm_counts: obj.moas_alarm_counts,
-                        submoas_alarm_counts: obj.submoas_alarm_counts,
                         hegemony_alarm_timebins: obj.hegemony_alarm_timebins,
                         network_delay_alarm_timebins: obj.network_delay_alarm_timebins,
-                        defcon_alarm_timebins: obj.defcon_alarm_timebins,
-                        edges_alarm_timebins: obj.edges_alarm_timebins,
-                        moas_alarm_timebins: obj.moas_alarm_timebins,
-                        submoas_alarm_timebins: obj.submoas_alarm_timebins,
-                    });
+                    }
+                    if (this.alarmDataSourcesFilter.grip) {
+                        alarmsByASNNumberInitial = {
+                            ...alarmsByASNNumberInitial,
+                            moas_alarm_counts: obj.moas_alarm_counts,
+                            submoas_alarm_counts: obj.submoas_alarm_counts,
+                            defcon_alarm_counts: obj.defcon_alarm_counts,
+                            edges_alarm_counts: obj.edges_alarm_counts,
+                            moas_alarm_timebins: obj.moas_alarm_timebins,
+                            submoas_alarm_timebins: obj.submoas_alarm_timebins,
+                            defcon_alarm_timebins: obj.defcon_alarm_timebins,
+                            edges_alarm_timebins: obj.edges_alarm_timebins,
+                        }
+                    }
+
+                    result.push(alarmsByASNNumberInitial);
                 }
 
                 return result;
@@ -191,18 +259,17 @@ export default {
             return alarmsByCountry
         },
 
-        processAlarmCategories(alarmByCountryGroupedData) {
-            const alarmCategories = ["hegemony", "network_delay", "defcon", "edges", "moas", "submoas"];
+        processAlarmTypes(alarmByCountryGroupedData, alarmTypes) {
             for (let i = 0; i < alarmByCountryGroupedData.length; i++) {
-                alarmCategories.forEach(category => {
-                    this.processAlarmCategory(category, alarmByCountryGroupedData[i])
+                alarmTypes.forEach(alarmType => {
+                    this.processAlarmType(alarmType, alarmByCountryGroupedData[i])
                 })
             }
         },
 
-        processAlarmCategory(alarmCategory, data) {
-            const counts = data[`${alarmCategory}_alarm_counts`];
-            const timebins = data[`${alarmCategory}_alarm_timebins`];
+        processAlarmType(alarmType, data) {
+            const counts = data[`${alarmType}_alarm_counts`];
+            const timebins = data[`${alarmType}_alarm_timebins`];
 
             const uniqueTimebins = timebins.filter((value, index, self) =>
                 self.findIndex(date => date.getTime() === value.getTime()) === index
@@ -220,19 +287,21 @@ export default {
                 summedCounts.push(countSum);
             });
 
-            data[`${alarmCategory}_alarm_counts`] = summedCounts;
+            data[`${alarmType}_alarm_counts`] = summedCounts;
         },
 
         processAggregatedAlarm(alarmsByCountryData) {
             alarmsByCountryData.forEach(aggregatedAlarm => {
-                const allTimebins = [
-                    ...aggregatedAlarm.hegemony_alarm_timebins,
-                    ...aggregatedAlarm.network_delay_alarm_timebins,
-                    ...aggregatedAlarm.moas_alarm_timebins,
-                    ...aggregatedAlarm.submoas_alarm_timebins,
-                    ...aggregatedAlarm.defcon_alarm_timebins,
-                    ...aggregatedAlarm.edges_alarm_timebins
-                ]
+                let allTimebins = [...aggregatedAlarm.hegemony_alarm_timebins, ...aggregatedAlarm.network_delay_alarm_timebins]
+                if (this.alarmDataSourcesFilter.grip) {
+                    allTimebins = [
+                        ...allTimebins,
+                        ...aggregatedAlarm.moas_alarm_timebins,
+                        ...aggregatedAlarm.submoas_alarm_timebins,
+                        ...aggregatedAlarm.defcon_alarm_timebins,
+                        ...aggregatedAlarm.edges_alarm_timebins]
+                }
+
                 let uniqueTimebins = allTimebins.filter((value, index, self) =>
                     self.findIndex(date => date.getTime() === value.getTime()) === index
                 );
@@ -242,11 +311,14 @@ export default {
 
                 aggregatedAlarm.hegemony_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
                 aggregatedAlarm.network_delay_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
-                aggregatedAlarm.moas_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
-                aggregatedAlarm.submoas_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
-                aggregatedAlarm.edges_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
-                aggregatedAlarm.defcon_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
                 aggregatedAlarm.total_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
+
+                if (this.alarmDataSourcesFilter.grip) {
+                    aggregatedAlarm.moas_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
+                    aggregatedAlarm.submoas_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
+                    aggregatedAlarm.edges_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
+                    aggregatedAlarm.defcon_alarm_count_across_timebins = Array(aggregatedAlarm.timebins.length).fill(0)
+                }
 
                 for (let i = 0; i < aggregatedAlarm.timebins.length; i++) {
                     const timebin = aggregatedAlarm.timebins[i]
@@ -260,37 +332,41 @@ export default {
                         aggregatedAlarm.network_delay_alarm_count_across_timebins[i] = aggregatedAlarm.network_delay_alarm_counts[network_delay_alarm_timebin_index] || 0
                     }
 
-                    const moas_delay_alarm_timebin_index = aggregatedAlarm.moas_alarm_timebins.findIndex(timebinValue => timebinValue.getTime() === timebin.getTime())
-                    if (moas_delay_alarm_timebin_index !== -1) {
-                        aggregatedAlarm.moas_alarm_count_across_timebins[i] = aggregatedAlarm.moas_alarm_counts[moas_delay_alarm_timebin_index] || 0
-                    }
+                    if (this.alarmDataSourcesFilter.grip) {
+                        const moas_delay_alarm_timebin_index = aggregatedAlarm.moas_alarm_timebins.findIndex(timebinValue => timebinValue.getTime() === timebin.getTime())
+                        if (moas_delay_alarm_timebin_index !== -1) {
+                            aggregatedAlarm.moas_alarm_count_across_timebins[i] = aggregatedAlarm.moas_alarm_counts[moas_delay_alarm_timebin_index] || 0
+                        }
 
-                    const submoas_alarm_timebin_index = aggregatedAlarm.submoas_alarm_timebins.findIndex(timebinValue => timebinValue.getTime() === timebin.getTime())
-                    if (submoas_alarm_timebin_index !== -1) {
-                        aggregatedAlarm.submoas_alarm_count_across_timebins[i] = aggregatedAlarm.submoas_alarm_counts[submoas_alarm_timebin_index] || 0
-                    }
+                        const submoas_alarm_timebin_index = aggregatedAlarm.submoas_alarm_timebins.findIndex(timebinValue => timebinValue.getTime() === timebin.getTime())
+                        if (submoas_alarm_timebin_index !== -1) {
+                            aggregatedAlarm.submoas_alarm_count_across_timebins[i] = aggregatedAlarm.submoas_alarm_counts[submoas_alarm_timebin_index] || 0
+                        }
 
-                    const edges_alarm_timebin_index = aggregatedAlarm.edges_alarm_timebins.findIndex(timebinValue => timebinValue.getTime() === timebin.getTime())
-                    if (edges_alarm_timebin_index !== -1) {
-                        aggregatedAlarm.edges_alarm_count_across_timebins[i] = aggregatedAlarm.edges_alarm_counts[edges_alarm_timebin_index] || 0
-                    }
+                        const edges_alarm_timebin_index = aggregatedAlarm.edges_alarm_timebins.findIndex(timebinValue => timebinValue.getTime() === timebin.getTime())
+                        if (edges_alarm_timebin_index !== -1) {
+                            aggregatedAlarm.edges_alarm_count_across_timebins[i] = aggregatedAlarm.edges_alarm_counts[edges_alarm_timebin_index] || 0
+                        }
 
-                    const defcon_alarm_timebin_index = aggregatedAlarm.defcon_alarm_timebins.findIndex(timebinValue => timebinValue.getTime() === timebin.getTime())
-                    if (defcon_alarm_timebin_index !== -1) {
-                        aggregatedAlarm.defcon_alarm_count_across_timebins[i] = aggregatedAlarm.defcon_alarm_counts[defcon_alarm_timebin_index] || 0
+                        const defcon_alarm_timebin_index = aggregatedAlarm.defcon_alarm_timebins.findIndex(timebinValue => timebinValue.getTime() === timebin.getTime())
+                        if (defcon_alarm_timebin_index !== -1) {
+                            aggregatedAlarm.defcon_alarm_count_across_timebins[i] = aggregatedAlarm.defcon_alarm_counts[defcon_alarm_timebin_index] || 0
+                        }
                     }
                 }
 
                 for (let i = 0; i < aggregatedAlarm.total_alarm_count_across_timebins.length; i++) {
                     aggregatedAlarm.total_alarm_count_across_timebins[i] =
                         aggregatedAlarm.hegemony_alarm_count_across_timebins[i] +
-                        aggregatedAlarm.network_delay_alarm_count_across_timebins[i] +
-                        aggregatedAlarm.moas_alarm_count_across_timebins[i] +
-                        aggregatedAlarm.submoas_alarm_count_across_timebins[i] +
-                        aggregatedAlarm.edges_alarm_count_across_timebins[i] +
-                        aggregatedAlarm.defcon_alarm_count_across_timebins[i]
+                        aggregatedAlarm.network_delay_alarm_count_across_timebins[i]
+                    if (this.alarmDataSourcesFilter.grip) {
+                        aggregatedAlarm.total_alarm_count_across_timebins[i] +=
+                            aggregatedAlarm.moas_alarm_count_across_timebins[i] +
+                            aggregatedAlarm.submoas_alarm_count_across_timebins[i] +
+                            aggregatedAlarm.defcon_alarm_count_across_timebins[i] +
+                            aggregatedAlarm.edges_alarm_count_across_timebins[i]
+                    }
                 }
-
             });
         },
 
@@ -314,17 +390,23 @@ export default {
                 asn_name: 'All',
                 hegemony_alarm_counts: [],
                 network_delay_alarm_counts: [],
-                defcon_alarm_counts: [],
-                edges_alarm_counts: [],
-                moas_alarm_counts: [],
-                submoas_alarm_counts: [],
                 hegemony_alarm_timebins: [],
                 network_delay_alarm_timebins: [],
-                defcon_alarm_timebins: [],
-                edges_alarm_timebins: [],
-                moas_alarm_timebins: [],
-                submoas_alarm_timebins: [],
-                timebins: []
+                timebins: [],
+            }
+
+            if (this.alarmDataSourcesFilter.grip) {
+                totalAlarmCountsRecord = {
+                    ...totalAlarmCountsRecord,
+                    defcon_alarm_counts: [],
+                    edges_alarm_counts: [],
+                    moas_alarm_counts: [],
+                    submoas_alarm_counts: [],
+                    defcon_alarm_timebins: [],
+                    edges_alarm_timebins: [],
+                    moas_alarm_timebins: [],
+                    submoas_alarm_timebins: [],
+                }
             }
 
             groupedData.forEach(alarm => {
@@ -348,12 +430,16 @@ export default {
                 for (let j = 0; j < timebins.length; j++) {
                     const hegemonyCount = data[i].hegemony_alarm_count_across_timebins[j] || 0;
                     const networkDelayCount = data[i].network_delay_alarm_count_across_timebins[j] || 0;
-                    const moasCount = data[i].moas_alarm_count_across_timebins[j] || 0;
-                    const submoasCount = data[i].submoas_alarm_count_across_timebins[j] || 0;
-                    const defconCount = data[i].defcon_alarm_count_across_timebins[j] || 0;
-                    const edgesCount = data[i].edges_alarm_count_across_timebins[j] || 0;
+                    if (this.alarmDataSourcesFilter.grip) {
+                        const moasCount = data[i].moas_alarm_count_across_timebins[j] || 0;
+                        const submoasCount = data[i].submoas_alarm_count_across_timebins[j] || 0;
+                        const defconCount = data[i].defcon_alarm_count_across_timebins[j] || 0;
+                        const edgesCount = data[i].edges_alarm_count_across_timebins[j] || 0;
+                        row.push([hegemonyCount, networkDelayCount, moasCount, submoasCount, defconCount, edgesCount]);
+                    } else {
+                        row.push([hegemonyCount, networkDelayCount])
+                    }
 
-                    row.push([hegemonyCount, networkDelayCount, moasCount, submoasCount, defconCount, edgesCount]);
                 }
 
                 result.push(row);
@@ -365,6 +451,18 @@ export default {
         drawChart(data, customHoverData, name) {
             let traces = []
             for (let i = 0; i < data.length; i++) {
+                let hovertemplate =
+                    '<b>%{x|%Y-%m-%d} at %{x|%I:%M %p}</b><br>' +
+                    'Total Alarm Counts: %{y}<br>' +
+                    'Hegemony Alarm Counts: %{customdata[0]}<br>' +
+                    'Network Delay Alarm Counts: %{customdata[1]}<br>'
+                if (this.alarmDataSourcesFilter.grip) {
+                    hovertemplate +=
+                        'Moas Alarm Counts: %{customdata[2]}<br>' +
+                        'SubMoas Alarm Counts: %{customdata[3]}<br>' +
+                        'Defcon Alarm Counts: %{customdata[4]}<br>' +
+                        'Edges Alarm Counts: %{customdata[5]}<br>'
+                }
                 let trace = {
                     x: data[i].timebins,
                     y: data[i].total_alarm_count_across_timebins,
@@ -372,15 +470,7 @@ export default {
                     mode: 'lines',
                     name: data[i][name],
                     customdata: customHoverData[i],
-                    hovertemplate:
-                        '<b>%{x|%Y-%m-%d} at %{x|%I:%M %p}</b><br>' +
-                        'Total Alarm Counts: %{y}<br>' +
-                        'Hegemony Alarm Counts: %{customdata[0]}<br>' +
-                        'Network Delay Alarm Counts: %{customdata[1]}<br>' +
-                        'Moas Alarm Counts: %{customdata[2]}<br>' +
-                        'SubMoas Alarm Counts: %{customdata[3]}<br>' +
-                        'Defcon Alarm Counts: %{customdata[4]}<br>' +
-                        'Edges Alarm Counts: %{customdata[5]}<br>',
+                    hovertemplate: hovertemplate,
                     marker: {
                         line: {
                             color: 'rgb(255,255,255)',

--- a/src/views/charts/global/AggregatedAlarmsTimeSeries.vue
+++ b/src/views/charts/global/AggregatedAlarmsTimeSeries.vue
@@ -1,4 +1,4 @@
-<template>
+f<template>
     <div class="IHR_chart">
         <div>
             <button @click="resetTimeSeries">Reset</button>
@@ -77,7 +77,6 @@ export default {
             this.addTotalAlarmCountsRecord(groupedAlarms)
             this.processAggregatedAlarm(groupedAlarms)
             this.sortAlarmsByCountry(groupedAlarms)
-            console.log('groupedAlarms:', groupedAlarms)
             const customHoverData = this.getCustomHoverData(groupedAlarms)
             this.drawChart(groupedAlarms, customHoverData, legendName);
             this.loading = false
@@ -86,7 +85,7 @@ export default {
 
     methods: {
         resetTimeSeries() {
-            if (this.chart.traces.length) {
+            if (!this.loading) {
                 this.untoggleLegend(this.chart.traces)
                 this.$emit('time-series-reset')
             }
@@ -408,6 +407,6 @@ export default {
 
 <style>
 .IHR_chart {
-    height: 340px;
+    height: 380px;
 }
 </style>

--- a/src/views/charts/global/AggregatedAlarmsTimeSeriesReactive.vue
+++ b/src/views/charts/global/AggregatedAlarmsTimeSeriesReactive.vue
@@ -16,8 +16,13 @@ export default {
         },
         loading: {
             type: Boolean,
-            default: true,
+            required: true,
         },
+        aggregatedAlarms: {
+            type: Array,
+            required: false,
+            default: () => [],
+        }
     },
     data() {
         return {
@@ -37,9 +42,9 @@ export default {
             },
             deep: true
         },
-        chart: {
-            handler: function (newChart) {
-                if (!this.loading && !newChart.traces.length) {
+        aggregatedAlarms: {
+            handler: function () {
+                if (!this.loading && !this.aggregatedAlarms.length) {
                     this.noData = this.$t('No data to show')
                 }
             },

--- a/src/views/charts/global/AggregatedAlarmsTimeSeriesReactive.vue
+++ b/src/views/charts/global/AggregatedAlarmsTimeSeriesReactive.vue
@@ -29,15 +29,16 @@ export default {
     watch: {
         loading: {
             handler: function () {
-                let noDataToShow = !this.loading && !this.chart.traces.length
-                if (noDataToShow) {
+                if (!this.loading && !this.chart.traces.length) {
                     this.noData = this.$t('No data to show')
                 } else if (!this.loading) {
                     this.noData = false
+                } else {
+                    this.noData = this.$t('loading')
                 }
-            }
-        }
 
+            }
+        },
     },
 
 }

--- a/src/views/charts/global/AggregatedAlarmsTimeSeriesReactive.vue
+++ b/src/views/charts/global/AggregatedAlarmsTimeSeriesReactive.vue
@@ -28,19 +28,24 @@ export default {
 
     watch: {
         loading: {
-            handler: function () {
-                if (!this.loading && !this.chart.traces.length) {
-                    this.noData = this.$t('No data to show')
-                } else if (!this.loading) {
+            handler: function (newLoadingValue) {
+                if (!newLoadingValue) {
                     this.noData = false
                 } else {
                     this.noData = this.$t('loading')
                 }
-
-            }
+            },
+            deep: true
         },
+        chart: {
+            handler: function (newChart) {
+                if (!this.loading && !newChart.traces.length) {
+                    this.noData = this.$t('No data to show')
+                }
+            },
+            deep: true
+        }
     },
-
 }
 </script>
   

--- a/src/views/charts/global/AggregatedAlarmsWorldMap.vue
+++ b/src/views/charts/global/AggregatedAlarmsWorldMap.vue
@@ -70,6 +70,10 @@ export default {
       type: Array,
       required: true,
       default: () => []
+    },
+    loading: {
+      type: Boolean,
+      required: true,
     }
   },
   emits: {
@@ -319,16 +323,17 @@ export default {
     },
 
     apiCall() {
-      this.loading = true
+      this.$emit('loading', true)
       if (this.networkDelayAlarms.length && this.hegemonyAlarms.length && Object.values(this.alarmDataSourcesFilter).includes(true)) {
         this.etlAlarms().then(() => {
-          this.loading = false;
+          this.$emit('loading', false)
         }).catch(error => {
           console.error(error)
         })
       } else if (!Object.values(this.alarmDataSourcesFilter).includes(true)) {
         this.clearWorldMap()
-        this.loading = false
+        this.$emit('aggregated-alarms-data-loaded', [])
+        this.$emit('loading', false)
       }
     },
 
@@ -354,7 +359,6 @@ export default {
               reject(error)
             })
         }
-
       })
     },
 
@@ -371,7 +375,7 @@ export default {
               .catch(error => {
                 reject(error)
               })
-          } else if (this.alarmDataSourcesFilter.grip && this.gripAlarms.data && !this.gripAlarms.downloading) {
+          } else if (this.alarmDataSourcesFilter.grip && this.gripAlarms.data) {
             resolve({ gripAlarms: this.gripAlarms.data })
           }
         })

--- a/src/views/charts/global/AggregatedAlarmsWorldMapReactive.vue
+++ b/src/views/charts/global/AggregatedAlarmsWorldMapReactive.vue
@@ -49,8 +49,10 @@ export default {
       }
     },
     plotlyClickedData: {
-      handler: function () {
-        this.$emit('plotly-click', this.plotlyClickedData)
+      handler: function (newPlotlyClickedData) {
+        if (newPlotlyClickedData) {
+          this.$emit('plotly-click', newPlotlyClickedData)
+        }
       }
     }
 

--- a/src/views/charts/global/AggregatedAlarmsWorldMapReactive.vue
+++ b/src/views/charts/global/AggregatedAlarmsWorldMapReactive.vue
@@ -38,16 +38,22 @@ export default {
   },
   watch: {
     loading: {
-      handler: function () {
-        if (!this.loading && !this.chart.traces.length) {
-          this.noData = this.$t('No data to show')
-        } else if (!this.loading) {
+      handler: function (newLoadingValue) {
+        if (!newLoadingValue) {
           this.noData = false
         } else {
           this.noData = this.$t('loading')
         }
-
-      }
+      },
+      deep: true
+    },
+    chart: {
+      handler: function (newChart) {
+        if (!this.loading && !newChart.traces[0].locations.length) {
+          this.noData = this.$t('No data to show')
+        }
+      },
+      deep: true
     },
     plotlyClickedData: {
       handler: function (newPlotlyClickedData) {

--- a/src/views/charts/global/AggregatedAlarmsWorldMapReactive.vue
+++ b/src/views/charts/global/AggregatedAlarmsWorldMapReactive.vue
@@ -36,16 +36,17 @@ export default {
       noData: this.$t('loading')
     }
   },
-
   watch: {
     loading: {
       handler: function () {
-        let noDataToShow = !this.loading && !this.chart.traces.length
-        if (noDataToShow) {
+        if (!this.loading && !this.chart.traces.length) {
           this.noData = this.$t('No data to show')
         } else if (!this.loading) {
           this.noData = false
+        } else {
+          this.noData = this.$t('loading')
         }
+
       }
     },
     plotlyClickedData: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces the bug fix to mismatch loading time series when IHR Data Source is unselected and then selected.

## Motivation and Context
The current inconsistent state of loading state for Time Series when the IHR data source is unselected and then selected. This pull request addresses this problem by implementing a centralized loading state.

This pull request also addresses the following issue #515

## How Has This Been Tested?
I have extensively tested these changes to ensure their effectiveness and reliability. Here are the details of my testing:

- Checked out the `alarm-corr-aggr` branch.
- Ran the Vue.js Web Application.
- Navigated to the Global Report Page.
- Waited for the data to load hegemony and network_delay alarms by default
- Unselected IHR Data Source and then selected IHR Data Source noticed that data is shown on the Time Series.

## Recordings
https://github.com/InternetHealthReport/ihr-website/assets/69568555/247fd0a9-c86b-4fda-8816-c01c95e83909

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
