### PR TITLE
remove counters in the Global Report

### DIFF
--- a/src/views/GlobalReport.vue
+++ b/src/views/GlobalReport.vue
@@ -11,6 +11,7 @@
         <!-- <button @click="generateReport()" class="np-btn">Generate Report</button> -->
       </div>
     </div>
+<!--
     <q-card class="q-mb-xl" flat>
       <q-card-section>
         <div class="row justify-center q-pa-md">
@@ -54,6 +55,7 @@
       </q-card-section>
       <q-separator />
     </q-card>
+ -->
     <q-expansion-item caption="IHR Aggregated Alarms" header-class="IHR_charts-title" default-opened expand-icon-toggle
       v-model="aggregatedAlarmsExpanded">
       <template v-slot:header>


### PR DESCRIPTION
Remove the top counters and filter on the global report page so that the aggregated alarms appear at the top of the global report page.

## Motivation and Context

The counters are too redundant with the aggregated alarms and are only related to the below tables.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
