### PR TITLE
Fix GRIP CORS problem

### DIFF
--- a/src/models/AggregatedAlarmsDataModel.js
+++ b/src/models/AggregatedAlarmsDataModel.js
@@ -221,7 +221,7 @@ function gripSeverityMapper(alarm) {
   if (severityValue >= 80 && severityValue <= 100) {
     severityLabel = 'high'
   } else if (severityValue >= 21 && severityValue <= 79) {
-    severityLabel = 'normal'
+    severityLabel = 'medium'
   } else if (severityValue >= 0 && severityValue <= 20) {
     severityLabel = 'low'
   }
@@ -235,7 +235,7 @@ function iodaSeverityMapper(alarm) {
   if (severityValue === 'critical') {
     severityLabel = 'high'
   } else if (severityValue === 'normal') {
-    severityLabel = 'normal'
+    severityLabel = 'medium'
   } else {
     severityLabel = 'low'
   }
@@ -248,7 +248,7 @@ function ihrSeverityMapper(alarm) {
   if (severityValue >= 20 && severityValue <= 30) {
     severityLabel = 'low'
   } else if (severityValue >= 31 && severityValue <= 50) {
-    severityLabel = 'normal'
+    severityLabel = 'medium'
   } else if (severityValue >= 51) {
     severityLabel = 'high'
   } else {

--- a/src/plugins/GripApi.js
+++ b/src/plugins/GripApi.js
@@ -1,7 +1,7 @@
 import * as AggregatedAlarmsUtils from '../models/AggregatedAlarmsUtils'
 import axios from 'axios'
 
-export function getGripAlarms(gripAlarmsState, startTime, endTime, timezone = '', minSuspicionLevel = 0, maxSuspicionLevel = 100, eventType = 'all', onePage = false) {
+export function getGripAlarms(gripAlarmsState, startTime, endTime, timezone = '', minSuspicionLevel = 80, maxSuspicionLevel = 100, eventType = 'all', onePage = false) {
   const request = () => {
     return new Promise((resolve, reject) => {
       if (gripAlarmsState.data) {
@@ -23,8 +23,8 @@ export function getGripAlarms(gripAlarmsState, startTime, endTime, timezone = ''
   return request()
 }
 
-function getGripAlarmsHelper(startTime, endTime, timezone = '', minSuspicionLevel = 0, maxSuspicionLevel = 100, eventType = 'all', onePage) {
-  const API_URL = 'https://api.grip.inetintel.cc.gatech.edu/json/events';
+function getGripAlarmsHelper(startTime, endTime, timezone = '', minSuspicionLevel = 80, maxSuspicionLevel = 100, eventType = 'all', onePage) {
+  const API_URL = 'https://ihr.iijlab.net/proxy/grip/events';
 
   const chunkSize = 100;
   const startUTCTimeFormatted = AggregatedAlarmsUtils.formatUTCTime(startTime, timezone)

--- a/src/plugins/IodaApi.js
+++ b/src/plugins/IodaApi.js
@@ -24,7 +24,7 @@ export function getIodaAlarms(iodaAlarmsState, startTime, endTime, timezone='00Z
 }
 
 function getIodaAlarmsHelper(startTime, endTime, timezone, entityType, ignoreMethods) {
-  const API_URL = 'https://api.ioda.inetintel.cc.gatech.edu/v2/outages/alerts'
+  const API_URL = 'https://ihr.iijlab.net/proxy/ioda/alerts'
 
   const startUTCTimeFormatted = AggregatedAlarmsUtils.formatUTCTime(startTime, timezone)
   const endUTCTimeFormatted = AggregatedAlarmsUtils.formatUTCTime(endTime, timezone)


### PR DESCRIPTION
The global report had a problem to show GRIP alarms because of CORS checks.
The code is now using a proxy server hosted by IHR to fetch GRIP and IODA data.

This code also raise the default minimum suspicion value for GRIP, in order to focus only on important alarms.