### PR TITLE
Issue 645 naviagtion duplicated bug fixed

### DIFF
--- a/src/views/Countries.vue
+++ b/src/views/Countries.vue
@@ -199,16 +199,16 @@ export default {
   },
   methods: {
     pushRoute() {
-      this.$router.replace({
-        //this.$router.replace({ query: Object.assign({}, this.$route.query, { hege_dt: clickData.points[0].x, hege_tb: table }) });
-        query: Object.assign({}, this.$route.query, {
-          af: this.family,
-          last: this.interval.dayDiff(),
-          date: this.$options.filters.ihrUtcString(this.interval.end, false),
-        }),
-      })
-      this.loadingStatus = LOADING_STATUS.LOADED
-      this.fetch = true
+      const currentQuery = {
+        af: String(this.family),
+        last: String(this.interval.dayDiff()),
+        date: this.$options.filters.ihrUtcString(this.interval.end, false),
+      };
+      if ( JSON.stringify(currentQuery) !== JSON.stringify(this.$route.query)) {
+        this.$router.replace({ query: currentQuery, hash: this.$route.hash });
+        this.loadingStatus = LOADING_STATUS.LOADED
+        this.fetch = true
+      }
     },
     displayNetDelay(displayValue) {
       this.show.net_delay = displayValue

--- a/src/views/Networks.vue
+++ b/src/views/Networks.vue
@@ -284,14 +284,15 @@ export default {
   },
   methods: {
     pushRoute() {
-      this.$router.replace({
-        //this.$router.replace({ query: Object.assign({}, this.$route.query, { hege_dt: clickData.points[0].x, hege_tb: table }) });
-        query: Object.assign({}, this.$route.query, {
-          af: this.family,
-          last: this.interval.dayDiff(),
-          date: this.$options.filters.ihrUtcString(this.interval.end, false),
-        }),
-      })
+      const currentQuery = {
+        af: String(this.family),
+        last: String(this.interval.dayDiff()),
+        date: this.$options.filters.ihrUtcString(this.interval.end, false),
+      };
+
+      if ( JSON.stringify(currentQuery) !== JSON.stringify(this.$route.query)) {
+        this.$router.replace({ query: currentQuery, hash: this.$route.hash });
+      }
     },
     netName() {
       let filter = new NetworkQuery().asNumber(this.asNumber)

--- a/src/views/ROV.vue
+++ b/src/views/ROV.vue
@@ -62,16 +62,16 @@ export default {
   },
   methods: {
     pushRoute() {
-      this.$router.replace({
-        //this.$router.replace({ query: Object.assign({}, this.$route.query, { hege_dt: clickData.points[0].x, hege_tb: table }) });
-        query: Object.assign({}, this.$route.query, {
-          af: this.family,
-          last: this.interval.dayDiff(),
-          date: this.$options.filters.ihrUtcString(this.interval.end, false),
-        }),
-      })
-      this.loadingStatus = LOADING_STATUS.LOADED
-      this.fetch = true
+      const currentQuery = {
+        af: String(this.family),
+        last: String(this.interval.dayDiff()),
+        date: this.$options.filters.ihrUtcString(this.interval.end, false),
+      };
+      if ( JSON.stringify(currentQuery) !== JSON.stringify(this.$route.query)) {
+        this.$router.replace({ query: currentQuery, hash: this.$route.hash });
+        this.loadingStatus = LOADING_STATUS.LOADED
+        this.fetch = true
+      }
     },
     displayNetDelay(displayValue) {
       this.show.net_delay = displayValue


### PR DESCRIPTION
Issue #645 : Navigation duplication bug fixed (navigation route was duplicated because of “redundantly” replacing the same route with the same parameters).

## Description
Added a if check statement to check whether the parameters are new parameters or the existing ones and only allowing entry replacement in history stack if new parameters

## Motivation and Context
This issue was raised. #645 

## Screenshots (if appropriate):
**Screenshot before bugfix(official website):**
<img width="1438" alt="Screenshot 0005-12-03 at 23 24 25" src="https://github.com/InternetHealthReport/ihr-website/assets/91608996/c53a4d24-e4e4-42a3-bbcd-1141c91178c2">

**Screenshots after bugfix (localhost):**
<img width="1436" alt="Screenshot 0005-12-03 at 23 25 44" src="https://github.com/InternetHealthReport/ihr-website/assets/91608996/8c1f03aa-69b1-4e76-bf08-4961f6221bd1">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
