### PR TITLE
Fixed the width in mobile devices in COVID-19 Reports page

### DIFF
--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -34,7 +34,7 @@
         </div>
       </div>
       <div class="row toolbox">
-        <div>
+        <div class="offset-10">
           <h3>Toolbox</h3>
           <q-toggle v-model="searchBar" label="Add more destination networks" />
         </div>
@@ -213,8 +213,8 @@ export default {
     visibility hidden
 
 .toolbox
-    padding 16px
-    justify-content: flex-end
+    margin-right 12pt
+    margin-top 15pt
 
 p
     font-size 1.2rem

--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -34,7 +34,7 @@
         </div>
       </div>
       <div class="row toolbox">
-        <div class="offset-10">
+        <div>
           <h3>Toolbox</h3>
           <q-toggle v-model="searchBar" label="Add more destination networks" />
         </div>
@@ -213,8 +213,8 @@ export default {
     visibility hidden
 
 .toolbox
-    margin-right 12pt
-    margin-top 15pt
+    padding 16px
+    justify-content: flex-end
 
 p
     font-size 1.2rem

--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -4,7 +4,7 @@
       <h1 class="text-center">Network Delays During National Lockdowns</h1>
 
       <div class="row justify-center">
-        <div class="col-6 IHR_description q-pa-lg">
+        <div class="IHR_description q-pa-lg">
           <p>
             As part of the
             <a href="https://labs.ripe.net/Members/becha/hackathons-in-the-time-of-corona" targeet="_blank"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed the width in mobile devices in COVID-19 Reports page

## Motivation and Context

Previous it was only using 50% of width in mobile devices
Now it is using 100% in mobile devices
#671

## Screenshots (if appropriate):
Before
![Before](https://github.com/InternetHealthReport/ihr-website/assets/113178195/5a1dc8f4-41ff-4a5b-9ab0-eb4671ea4f4f)

After
![After](https://github.com/InternetHealthReport/ihr-website/assets/113178195/180c41f0-5be1-40d6-b69b-7566336425ff)




## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (#671)

## Checklist:

- [x] My code follows the code style of this project.
