### PR TITLE
Fixed Toolbox in the COVID-19 Reports Page

### DIFF
--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -34,7 +34,7 @@
         </div>
       </div>
       <div class="row toolbox">
-        <div class="offset-10">
+        <div>
           <h3>Toolbox</h3>
           <q-toggle v-model="searchBar" label="Add more destination networks" />
         </div>
@@ -213,8 +213,8 @@ export default {
     visibility hidden
 
 .toolbox
-    margin-right 12pt
-    margin-top 15pt
+    padding 16px
+    justify-content: flex-end
 
 p
     font-size 1.2rem


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed Toolbox in the COVID-19 Reports Page which was overflowing causing horizontal scroll bar.

## Motivation and Context

Fixed the Toolbox overflowing issue which was causing horizontal scroll bar.
#670 


## Screenshots (if appropriate):
Before
![Before](https://github.com/InternetHealthReport/ihr-website/assets/113178195/7855f432-12c3-4eec-8e69-ddf1546527dc)
After
![After](https://github.com/InternetHealthReport/ihr-website/assets/113178195/fd6809fa-64b1-4a39-b738-d9559c098b52)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
