### PR TITLE
Fixed Horizontal Scroll bar in Docs And Contact page

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -8,7 +8,7 @@ import Tr from '@/i18n/translation'
   <QFooter elevated primary class="IHR_footer text-white text-center ">
     <div class="IHR_footer_contents">
       <div class="IHR_fsection">
-        <div class="" style="width:360px;max-width: 400px;">
+        <div class="" style="max-width: 400px;">
           <div>
             <RouterLink :to="Tr.i18nRoute({ name: 'home' })">
               <QBtn round dense flat :ripple="false" no-caps>

--- a/src/views/Contact.vue
+++ b/src/views/Contact.vue
@@ -73,4 +73,6 @@
       text-align left
       @media screen and (max-width: 600px)
         font-size 12pt
+      & > a
+        word-break break-word
 </style>

--- a/src/views/Documentation.vue
+++ b/src/views/Documentation.vue
@@ -207,6 +207,14 @@ const sectionActive = ref('')
         overflow-anchor none
         & > a
           overflow-anchor none
+          word-break break-word
+        & > ul
+          & > li
+            & > a
+              word-break break-word
+        & > p
+          & > a
+            word-break break-word
 #cod
       background-color: #e7e9eb
       padding:1em


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The links in the documentation and Contacts page were not responsive.
Also the footer width was fixed size causing overflowing issue.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
#672 

## Screenshots (if appropriate):
Before
![Before 1](https://github.com/InternetHealthReport/ihr-website/assets/113178195/4b40ea08-fbdb-4ff4-a4ac-a59c46ee6543)
After
![After 1](https://github.com/InternetHealthReport/ihr-website/assets/113178195/6dc05b59-f8fc-4226-b866-e14897a35e21)



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
