### PR TITLE
Fixed the width in COVID-19 Reports page

### DIFF
--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -91,7 +91,7 @@ watch(selected, (newValue) => {
       <h1 class="text-center">Network Delays During National Lockdowns</h1>
 
       <div class="row justify-center">
-        <div class="col-6 IHR_description q-pa-lg">
+        <div class="IHR_description q-pa-lg">
           <p>
             As part of the
             <a href="https://labs.ripe.net/Members/becha/hackathons-in-the-time-of-corona" targeet="_blank"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed the width in mobile devices in COVID-19 Reports page

## Motivation and Context

Previous it was only using 50% of width in mobile devices
Now it is using 100% in mobile devices
#671 

## Screenshots (if appropriate):
Before
![Before 5](https://github.com/InternetHealthReport/ihr-website/assets/113178195/62190be5-1360-4e34-86d1-153463278ffd)
After
![After 5](https://github.com/InternetHealthReport/ihr-website/assets/113178195/3a4246c7-75cf-41fb-8c7b-30c4098dc2be)

