### PR TITLE
Fixed Toolbox in the COVID-19 Reports Page

### DIFF
--- a/src/views/Corona.vue
+++ b/src/views/Corona.vue
@@ -120,7 +120,7 @@ watch(selected, (newValue) => {
         </div>
       </div>
       <div class="row toolbox">
-        <div class="offset-10">
+        <div>
           <h3>Toolbox</h3>
           <QToggle v-model="searchBar" label="Add more destination networks" />
         </div>
@@ -195,8 +195,8 @@ watch(selected, (newValue) => {
     visibility hidden
 
 .toolbox
-    margin-right 12pt
-    margin-top 15pt
+    padding 16px
+    justify-content: flex-end
 
 p
     font-size 1.2rem


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed Toolbox in the COVID-19 Reports Page which was overflowing causing horizontal scroll bar.

## Motivation and Context

Fixed the Toolbox overflowing issue which was causing horizontal scroll bar.
#670 


## Screenshots (if appropriate):
Before
![Before 6](https://github.com/InternetHealthReport/ihr-website/assets/113178195/3577c9dc-44ae-4e17-a05f-6658a5595f43)
After
![After 6](https://github.com/InternetHealthReport/ihr-website/assets/113178195/6c3f3e54-ffc4-4407-850b-2b1497f5e2a2)


