### PR TITLE
Bug/issue735

### DIFF
--- a/src/components/maps/WorldMapAggregatedAlarmsMap.vue
+++ b/src/components/maps/WorldMapAggregatedAlarmsMap.vue
@@ -11,7 +11,7 @@ const props = defineProps({
       hovertemplate: '',
       locations: [],
       text: [],
-      z: []
+      z: [],
     }
   },
   loading: {
@@ -39,6 +39,8 @@ const traces = ref([
     type: 'choropleth',
     locations: [],
     z: [],
+    zmin: 0,
+    zmax: 0,
     text: [],
     name: '',
     customdata: [],
@@ -60,6 +62,7 @@ const traces = ref([
     }
   },
 ])
+const zmax = ref(null)
 
 const clearDataViz = () => {
   traces.value[0].locations = []
@@ -72,6 +75,18 @@ const setTraces = () => {
   traces.value[0].locations = props.data.locations
   traces.value[0].text = props.data.text
   traces.value[0].z = props.data.z
+  console.log(traces.value[0].customdata)
+  if(traces.value[0].customdata){
+    const max = Math.max(...traces.value[0].customdata.map(o => o.hegemony_count), 0)
+    if(zmax.value == null){
+      zmax.value = max
+      traces.value[0].zmax = max
+    }
+    else {
+      traces.value[0].zmax = zmax.value
+    }
+  }
+  console.log(zmax.value)
 }
 
 watch(() => props.data, () => {

--- a/src/components/maps/WorldMapAggregatedAlarmsMap.vue
+++ b/src/components/maps/WorldMapAggregatedAlarmsMap.vue
@@ -75,7 +75,6 @@ const setTraces = () => {
   traces.value[0].locations = props.data.locations
   traces.value[0].text = props.data.text
   traces.value[0].z = props.data.z
-  console.log(traces.value[0].customdata)
   if(traces.value[0].customdata){
     const max = Math.max(...traces.value[0].customdata.map(o => o.hegemony_count), 0)
     if(zmax.value == null){
@@ -86,7 +85,6 @@ const setTraces = () => {
       traces.value[0].zmax = zmax.value
     }
   }
-  console.log(zmax.value)
 }
 
 watch(() => props.data, () => {


### PR DESCRIPTION
**Before**: on clicking a country color scale would change at global report page
**After**: color scale would remain consistent even after clicking a country

## Description

Added a ref, zmax = null
**Modified setTraces function inside WorldMapAggregatedAlarmsMap.vue file**
If zmax is null and traces.customdata has values then set traces.value[0].zmax = Max(All countries hegemony count)
This traces will be passed to Reactive Chart which in turn will pass traces to plotly.
By setting zmax = max(All countries hegemony count) and zmin = 0, the color scale will remain constant

## Motivation and Context
https://github.com/InternetHealthReport/ihr-website/issues/735

## How Has This Been Tested?
I clicked several countries after refreshing the page.
I clicked a country then clicked show all countries, then clicked a country again 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

@mohamedawnallah Please review my code. Also see if keeping zmax value = max of alarm counts is okay.
