### PR TITLE
Cypher CSS Fix

### DIFF
--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -52,7 +52,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <QMarkupTable class="card" dense bordered>
+  <QMarkupTable class="user-card" dense bordered>
     <thead>
       <th :colspan="2" align="center" style="border-bottom: 1px solid white;">
         <td style="font-size: large;">YOUR CONNECTION</td>
@@ -94,7 +94,7 @@ onMounted(() => {
 </template>
 
 <style lang="stylus">
-.card
+.user-card
   width inherit
   background-color rgba(0,0,0,0) !important
   border-color white !important


### PR DESCRIPTION
**BUG**

Due to the usage of .card in the UserInfo.vue component it conflicts with with other components that uses .card as class. 
And due to this cypher query was not displayed correctly.

![image](https://github.com/InternetHealthReport/ihr-website/assets/71931823/4c21b4c2-44e8-4ffb-98ae-90424ec22712)

![image](https://github.com/InternetHealthReport/ihr-website/assets/71931823/c6f1bb6f-e512-4fe7-a355-f883df49564b)


**Solution**

Changing the class name of .card in UserInfo.vue to .user-card


