### PR TITLE
global_report: Handle maximum recursive updates

### DIFF
--- a/src/components/tables/AggregatedAlarmsTable.vue
+++ b/src/components/tables/AggregatedAlarmsTable.vue
@@ -103,7 +103,7 @@ const emit = defineEmits(['country-clicked', 'asn-name-key-clicked', {
   }
 }])
 
-const { rows, filterFct, filterTable, getCellValue, dateHourShift, setRows } = commonTable(props, { emit })
+const { rows, dateHourShift, setRows } = commonTable(props, { emit })
 
 const columns = ref(ALARMS_INFO[props.selectedTableDataSource].alarm_types[props.selectedTableAlarmType].metadata.table_columns)
 const aggregatedColumns = ref(ALARMS_INFO[props.selectedTableDataSource].alarm_types[props.selectedTableAlarmType].metadata.table_aggregated_columns)
@@ -349,7 +349,7 @@ watch(() => props.selectedTableAlarmType, () => {
 
 <template>
   <QTable table-class="myClass" :rows="rows" :columns="[...columns, ...aggregatedColumns]" :pagination.sync="pagination"
-    :loading="loading" :filter="filter" :filter-method="filterFct" flat loading-label="Loading Alarms ..."
+    :loading="loading" :filter="filter" flat loading-label="Loading Alarms ..."
     :row-key="tableKeyCurrent" v-model:expanded="expandedRow">
     <template v-slot:body="props">
       <QTr :props="props">


### PR DESCRIPTION
## Description

Hey everyone!

I noticed an issue on the IHR website, specifically on the global report page. When a country is clicked, the site hangs for a while, though it works fine locally in dev mode. After investigating, I found that using `filter-fct` on the `QTable` is causing the problem. Removing it solves the issue.

## Motivation and Context

**Before:**
You would encounter an error like this (in dev mode locally), which I believe is the main reason why it was stuck:
![Error Screenshot](https://github.com/InternetHealthReport/ihr-website/assets/69568555/cd9d94d0-2499-4e95-a2e1-b7cee701f662)

**After:**
You will no longer see the error when clicking on a country on the world map.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.