### PR TITLE
Fix issue 806 - Missing y-label in network report chart

### DIFF
--- a/src/components/charts/ReactiveChart.vue
+++ b/src/components/charts/ReactiveChart.vue
@@ -143,9 +143,9 @@ onMounted(() => {
 watch(() => props.traces, () => {
   react()
 }, { deep: true })
-// watch(() => props.layout, () => {
-//   react()
-// })
+watch(() => props.layout, () => {
+  layoutLocal.value = Object.assign(layoutLocal.value, props.layout)
+})
 watch(() => props.yMax, (newValue) => {
   const graphDiv = myId.value
   Plotly.relayout(graphDiv, 'yaxis.range', [0, newValue])

--- a/src/components/iyp/as/ASOriginatedPrefixes.vue
+++ b/src/components/iyp/as/ASOriginatedPrefixes.vue
@@ -73,11 +73,12 @@ onMounted(() => {
             :chart-layout="{ title: 'Geo-location (Maxmind)' }" />
       </div>
       <div class="col-6">
-        <IypGenericBarChart 
-            v-if="prefixes.data.length > 0" 
-            :chart-data="prefixes.data" 
-            :config="{key:'tags'}" 
-            :chart-layout="{ title: 'Prefix tags' }" />
+        <IypGenericBarChart
+          v-if="prefixes.data.length > 0"
+          :chart-data="prefixes.data"
+          :config="{ key: 'tags' }"
+          :chart-layout="{yaxis: { title: { text: 'Number of prefixes' } }, title: 'Prefix tags',  }"
+        />
       </div>
       <div class="col-10">
       <IypGenericTreemapChart


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added y-label for prefix tags chart
- Fixed chart layout not updated when adding y-label or other properties
- This fix covers similar cases using y-label (which were not showed). Eg: ''Upstream'' ASes chart below
![image](https://github.com/InternetHealthReport/ihr-website/assets/172492661/9bfacf4c-983a-4703-a353-82cbee3920c2)


<!--- Describe your changes in detail -->

## Motivation and Context
Fix Issue #806 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on local machine
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/InternetHealthReport/ihr-website/assets/172492661/52a2b6aa-c277-43ca-92c8-af061a2787c7)
![image](https://github.com/InternetHealthReport/ihr-website/assets/172492661/a30ee018-4e2a-4607-b761-fa01492f60e2)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
