### PR TITLE
Implement navigation only for leaf nodes in Plotly treemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ihr-website",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/Feedback.vue
+++ b/src/components/Feedback.vue
@@ -11,7 +11,7 @@ const showFeedbackDialog = ref(false)
 		@click="showFeedbackDialog = true"
 		no-caps
 		unelevated
-		label="Give Feedback"
+		label="Feedback"
 		dense
 	/>
 	<QDialog v-model="showFeedbackDialog">

--- a/src/components/iyp/as/ASAuthoritativeNameservers.vue
+++ b/src/components/iyp/as/ASAuthoritativeNameservers.vue
@@ -59,7 +59,7 @@ onMounted(() => {
       v-if="nameservers.data.length > 0"
       :chart-data="nameservers.data"
       :config="{ keys: ['prefix', 'ip', 'nameserver'], root: pageTitle, hovertemplate: '<b>%{customdata.nameserver}<br>%{label}</b> <br><br><extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'nameserver'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/as/ASDownstreamsASes.vue
+++ b/src/components/iyp/as/ASDownstreamsASes.vue
@@ -69,7 +69,7 @@ onMounted(() => {
         :chart-data="downstreams.data"
         :chart-layout="{ title: '' }"
         :config="{ keys: ['af', 'cc', 'asn'], keyValue: 'hegemony_score', root: pageTitle, show_percent: true, hovertemplate: '<b>%{label}</b><br>%{customdata.name}<br><br> Hegemony value: %{customdata.hegemony_score:.2f}%<extra></extra>' }"
-        @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+        @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'asn'}})"
       />
     </div>
   </IypGenericTable>

--- a/src/components/iyp/as/ASIXPs.vue
+++ b/src/components/iyp/as/ASIXPs.vue
@@ -58,7 +58,7 @@ onMounted(() => {
     <IypGenericTreemapChart v-if="ixps.data.length > 0"
       :chart-data="ixps.data"
       :config="{ keys: ['cc', 'name'],  keyValue: '', root: pageTitle, show_percent: true }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'ixpName'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/as/ASOriginatedPrefixes.vue
+++ b/src/components/iyp/as/ASOriginatedPrefixes.vue
@@ -5,6 +5,7 @@ import IypGenericTable from '@/components/tables/IypGenericTable.vue'
 import IypGenericPieChart from '@/components/charts/IypGenericPieChart.vue'
 import IypGenericBarChart from '@/components/charts/IypGenericBarChart.vue'
 import IypGenericTreemapChart from '@/components/charts/IypGenericTreemapChart.vue'
+import treemapClicked from '@/plugins/IypGenericTreemapChart.js'
 
 const iyp_api = inject('iyp_api')
 
@@ -85,6 +86,7 @@ onMounted(() => {
         :chart-data="prefixes.data"
         :chart-layout="{ title: 'Breakdown per RIR and geo-location (Maxmind)' }"
         :config="{ keys: ['rir', 'cc', 'prefix'], root: pageTitle, show_percent: true, hovertemplate: '<b>%{label}</b><br>%{customdata.descr}<extra>%{customdata.percent:.1f}%</extra>' }"
+        @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'prefix'}})"
         />
       </div>
     </div>

--- a/src/components/iyp/as/ASPopularDomains.vue
+++ b/src/components/iyp/as/ASPopularDomains.vue
@@ -66,7 +66,7 @@ onMounted(() => {
       v-if="domains.data.length > 0"
       :chart-data="domains.data"
       :config="{ keys: ['tld', 'hostName'], keyValue: 'inv_rank', root: pageTitle, textinfo: 'label', hovertemplate: '<b>%{label}</b> <br><br>%{customdata.rankingName}: #%{customdata.rank}<extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'hostname'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/as/ASPopularHostNames.vue
+++ b/src/components/iyp/as/ASPopularHostNames.vue
@@ -66,7 +66,7 @@ onMounted(() => {
       v-if="domains.data.length > 0"
       :chart-data="domains.data"
       :config="{ keys: ['tld', 'hostName'], keyValue: 'inv_rank', root: pageTitle, textinfo: 'label', hovertemplate: '<b>%{label}</b> <br><br>%{customdata.rankingName}: #%{customdata.rank}<extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'hostname'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/as/ASRipeAtlas.vue
+++ b/src/components/iyp/as/ASRipeAtlas.vue
@@ -75,7 +75,7 @@ onMounted(() => {
         :chart-data="atlas.data"
         :chart-layout="{ title: 'RIPE Atlas probes per prefix' }"
         :config="{ keys: ['af', 'prefix', 'id'],  root: pageTitle, hovertemplate: '<b>%{label}</b><br>%{value} probes<extra></extra>' }"
-        @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+        @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'atlasId'}})"
         />
     </IypGenericTable>
 </template>

--- a/src/components/iyp/country/CountryASRankings.vue
+++ b/src/components/iyp/country/CountryASRankings.vue
@@ -67,7 +67,7 @@ onMounted(() => {
       v-if="rankings.data.length > 0"
       :chart-data="rankings.data"
       :config="{ keys: ['asn', 'rank_name'], keyValue: 'inv_rank', root: pageTitle, hovertemplate: '<b>%{customdata.asn} %{customdata.asname}</b> <br><br>%{customdata.rank_name}: #%{customdata.rank}<extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'rankName'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/country/CountryAutonomousSystems.vue
+++ b/src/components/iyp/country/CountryAutonomousSystems.vue
@@ -3,7 +3,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { ref, inject, watch, onMounted } from 'vue'
 import IypGenericTable from '@/components/tables/IypGenericTable.vue'
 import IypGenericTreemapChart from '@/components/charts/IypGenericTreemapChart.vue'
-import treemapClicked from '@/plugins/IypGenericTreemapChart.js'
 
 const iyp_api = inject('iyp_api')
 

--- a/src/components/iyp/country/CountryIPPrefixes.vue
+++ b/src/components/iyp/country/CountryIPPrefixes.vue
@@ -105,7 +105,7 @@ onMounted(() => {
           :chart-data="aggPrefixes"
           :chart-layout="{ title: 'Number of prefixes per Origin AS' }"
           :config="{ keys: ['asn'], keyValue: 'nbPrefixes', root: pageTitle, hovertemplate: '<b>%{label}</b><br>%{value} prefixes<extra></extra>' }"
-          @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+          @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'asn'}})"
         />
       </div>
     </div>

--- a/src/components/iyp/country/CountryInternetExchangePoints.vue
+++ b/src/components/iyp/country/CountryInternetExchangePoints.vue
@@ -68,7 +68,7 @@ onMounted(() => {
         :chart-data="ixps.data"
         :chart-layout="{ title: 'IXPs in '+pageTitle+' weighted by their number of members' }"
         :config="{ keys: ['org', 'ixp'], keyValue: 'nb_members', root: pageTitle, hovertemplate: '<b>%{label}</b><br>%{value} members<extra></extra>' }"
-        @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+        @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'ixpName'}})"
       />
     </div>
   </IypGenericTable>

--- a/src/components/iyp/country/CountryRipeAtlas.vue
+++ b/src/components/iyp/country/CountryRipeAtlas.vue
@@ -65,7 +65,7 @@ onMounted(() => {
       :chart-data="atlas.data"
       :chart-layout="{ title: 'RIPE Atlas probes per AS' }"
       :config="{ keys: ['af', 'asn', 'status', 'id'],  root: pageTitle, hovertemplate: '<b>%{label}</b><br>%{value} probes<extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'atlasId'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/hostName/HostNameAuthoritativeNameservers.vue
+++ b/src/components/iyp/hostName/HostNameAuthoritativeNameservers.vue
@@ -73,7 +73,7 @@ onMounted(() => {
           v-if="nameservers.data.length > 0"
           :chart-data="nameservers.data"
           :config="{ keys: ['asn', 'prefix', 'ip', 'nameserver'], root: pageTitle, hovertemplate: '<b>%{customdata.nameserver}<br>%{label}</b> <br><br><extra></extra>' }"
-          @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+          @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'nameserver'}})"
         />
       </div>
     </div>

--- a/src/components/iyp/hostName/HostNameIPAddressesPrefixes.vue
+++ b/src/components/iyp/hostName/HostNameIPAddressesPrefixes.vue
@@ -76,7 +76,7 @@ onMounted(() => {
           v-if="ips.data.length > 0"
           :chart-data="ips.data"
           :config="{ keys: ['asn', 'prefix', 'ip'], root: pageTitle, hovertemplate: '<b>%{label}<br>%{value}</b> <br><br><extra></extra>' }"
-          @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+          @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'ip'}})"
         />
       </div>
     </div>

--- a/src/components/iyp/hostName/HostNameQueryingASes.vue
+++ b/src/components/iyp/hostName/HostNameQueryingASes.vue
@@ -66,8 +66,8 @@ onMounted(() => {
     <IypGenericTreemapChart
       v-if="as_query.data.length > 0"
       :chart-data="as_query.data"
-      :config="{ keys: ['name'], keyValue: 'perc', root: pageTitle, hovertemplate: '<b>%{label}<br>%{value}%</b> <br><br><extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      :config="{ keys: ['asn'], keyValue: 'perc', root: pageTitle, hovertemplate: '<b>%{customdata.name}<br>%{value}%</b> <br><br><extra></extra>' }"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'asn'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/hostName/HostNameQueryingCountries.vue
+++ b/src/components/iyp/hostName/HostNameQueryingCountries.vue
@@ -64,7 +64,7 @@ onMounted(() => {
       v-if="country_query.data.length > 0"
       :chart-data="country_query.data"
       :config="{ keys: ['cc'], keyValue: 'perc', root: pageTitle, hovertemplate: '<b>%{label}<br>%{value}%</b> <br><br><extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'country'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/hostName/HostNameRankings.vue
+++ b/src/components/iyp/hostName/HostNameRankings.vue
@@ -4,7 +4,6 @@ import { ref, inject, watch, onMounted } from 'vue'
 import IypGenericTable from '@/components/tables/IypGenericTable.vue'
 import IypGenericTreemapChart from '@/components/charts/IypGenericTreemapChart.vue'
 import IypGenericBarChart from '@/components/charts/IypGenericBarChart.vue'
-import treemapClicked from '@/plugins/IypGenericTreemapChart.js'
 
 const iyp_api = inject('iyp_api')
 

--- a/src/components/iyp/prefix/PrefixAuthoritativeNameservers.vue
+++ b/src/components/iyp/prefix/PrefixAuthoritativeNameservers.vue
@@ -61,7 +61,7 @@ onMounted(() => {
       v-if="nameservers.data.length > 0"
       :chart-data="nameservers.data"
       :config="{ keys: ['tld', 'nameserver', 'ip'], root: getPrefix, hovertemplate: '<b>%{customdata.nameserver}<br>%{label}</b> <br><br>Manage %{customdata.nb_hostnames} popular Hostnames<extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'ip'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/prefix/PrefixPopularDomains.vue
+++ b/src/components/iyp/prefix/PrefixPopularDomains.vue
@@ -63,7 +63,7 @@ onMounted(() => {
       v-if="domains.data.length > 0"
       :chart-data="domains.data"
       :config="{ keys: ['tld', 'hostName', 'ip'], keyValue: 'inv_rank', root: getPrefix, hovertemplate: '<b>%{customdata.domain}<br>%{label}</b> <br><br>%{customdata.rankingName}: %{customdata.rank}<br>%{customdata.tags}<extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'ip'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/prefix/PrefixPopularHostNames.vue
+++ b/src/components/iyp/prefix/PrefixPopularHostNames.vue
@@ -61,7 +61,7 @@ onMounted(() => {
       v-if="domains.data.length > 0"
       :chart-data="domains.data"
       :config="{ keys: ['tld', 'hostName', 'ip'], keyValue: 'inv_rank', root: getPrefix, hovertemplate: '<b>%{customdata.domain}<br>%{label}</b> <br><br>%{customdata.rankingName}: %{customdata.rank}<br>%{customdata.tags}<extra></extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'ip'}})"
     />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/rank/RankASRankings.vue
+++ b/src/components/iyp/rank/RankASRankings.vue
@@ -3,7 +3,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { ref, inject, watch, onMounted } from 'vue'
 import IypGenericTable from '@/components/tables/IypGenericTable.vue'
 import IypGenericTreemapChart from '@/components/charts/IypGenericTreemapChart.vue'
-import treemapClicked from '@/plugins/IypGenericTreemapChart.js'
 
 const iyp_api = inject('iyp_api')
 

--- a/src/components/iyp/tag/TagAutonomousSystems.vue
+++ b/src/components/iyp/tag/TagAutonomousSystems.vue
@@ -74,7 +74,7 @@ onMounted(() => {
         :chart-data="asesViz"
         :chart-layout="{ title: 'Breakdown per RIR and registered country' }"
         :config="{ keys: ['rir', 'cc', 'asn'], root: tag, show_percent: true, hovertemplate: '<b>%{label}</b><br>%{customdata.name}<extra>%{customdata.percent:.1f}%</extra>' }"
-        @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+        @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'asn'}})"
         />
   </IypGenericTable>
 </template>

--- a/src/components/iyp/tag/TagPopularHostNames.vue
+++ b/src/components/iyp/tag/TagPopularHostNames.vue
@@ -3,7 +3,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { ref, inject, watch, onMounted } from 'vue'
 import IypGenericTable from '@/components/tables/IypGenericTable.vue'
 import IypGenericTreemapChart from '@/components/charts/IypGenericTreemapChart.vue'
-import treemapClicked from '@/plugins/IypGenericTreemapChart.js'
 
 const iyp_api = inject('iyp_api')
 

--- a/src/components/iyp/tag/TagPrefixes.vue
+++ b/src/components/iyp/tag/TagPrefixes.vue
@@ -75,7 +75,7 @@ onMounted(() => {
       :chart-data="prefixesViz"
       :chart-layout="{ title: 'Breakdown per origin AS and registered country code' }"
       :config="{ keys: ['as_cc', 'asn', 'prefix'], root: tag, show_percent: true, hovertemplate: '<b>%{label}</b><br>%{customdata.descr}<extra>%{customdata.percent:.1f}%</extra>' }"
-      @treemap-clicked="treemapClicked({...$event, ...{router: router}})"
+      @treemap-clicked="treemapClicked({...$event, ...{router: router, 'leafKey': 'prefix'}})"
       />
   </IypGenericTable>
 </template>

--- a/src/plugins/IypGenericTreemapChart.js
+++ b/src/plugins/IypGenericTreemapChart.js
@@ -5,10 +5,21 @@ import { isoCountries } from '@/plugins/countryName'
 const Address4 = ipAddress.Address4
 const Address6 = ipAddress.Address6
 
+function isLeafNode(nodeLabel, data) {
+  console.log(nodeLabel, data.parents)
+  // return false
+  for (let i=0; i<data.labels.length; i++) {
+    if (data.parents[i].includes(nodeLabel)) {
+      return false
+    }
+  }
+  return true
+}
+
 export default function treemapClicked(event) {
-  // console.log(event)
   if (event.points && event.points.length) {
     const network = event.points[0].label
+    console.log(network)
     if (typeof network === 'string') {
       let prefixMatch
       try {
@@ -25,7 +36,7 @@ export default function treemapClicked(event) {
       }
       const domainRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/
       const domainMatch = domainRegex.exec(network)
-      if (prefixMatch) {
+      if (prefixMatch && isLeafNode(network, event.points[0].data)) {
         const [host, prefixLength] = network.split('/')
         if (prefixLength) {
           event.router.push(Tr.i18nRoute({
@@ -33,30 +44,36 @@ export default function treemapClicked(event) {
             params: { ip: host, length: prefixLength },
           }))
         }
-      } else if (network.split(' ')[0] in isoCountries) {
+      } else if (network.split(' ')[0] in isoCountries && isLeafNode(network.split(' ')[0], event.points[0].data)) {
         event.router.push(Tr.i18nRoute({
           name: 'country',
           params: { cc: network.split(' ')[0] },
         }))
-      } else if (domainMatch) {
+      } else if (domainMatch && isLeafNode(network, event.points[0].data)) {
         event.router.push(Tr.i18nRoute({
           name: 'hostname',
           params: { hostname: network },
         }))
-      } else if (Number(network.replace('AS', ''))) {
+      } else if (Number(network.replace('AS', '')) && isLeafNode(network, event.points[0].data)) {
         event.router.push(Tr.i18nRoute({
           name: 'network',
           params: { id: network },
         }))
       }
     } else if (typeof network === 'object') {
-      if ('low' in network) {
+      if ('low' in network && isLeafNode(network.low, event.points[0].data)) {
         const asId = `AS${network.low}`
         event.router.push(Tr.i18nRoute({
           name: 'network',
           params: { id: asId },
         }))
       }
+    } else if (typeof network === 'number' && isLeafNode(network, event.points[0].data)) {
+      const asId = `AS${network}`
+      event.router.push(Tr.i18nRoute({
+        name: 'network',
+        params: { id: asId },
+      }))
     }
   }
 }

--- a/src/plugins/IypGenericTreemapChart.js
+++ b/src/plugins/IypGenericTreemapChart.js
@@ -6,8 +6,6 @@ const Address4 = ipAddress.Address4
 const Address6 = ipAddress.Address6
 
 function isLeafNode(nodeLabel, data) {
-  console.log(nodeLabel, data.parents)
-  // return false
   for (let i=0; i<data.labels.length; i++) {
     if (data.parents[i].includes(nodeLabel)) {
       return false
@@ -19,7 +17,6 @@ function isLeafNode(nodeLabel, data) {
 export default function treemapClicked(event) {
   if (event.points && event.points.length) {
     const network = event.points[0].label
-    console.log(network)
     if (typeof network === 'string') {
       let prefixMatch
       try {

--- a/src/plugins/IypGenericTreemapChart.js
+++ b/src/plugins/IypGenericTreemapChart.js
@@ -1,9 +1,4 @@
-import * as ipAddress from 'ip-address'
 import Tr from '@/i18n/translation'
-import { isoCountries } from '@/plugins/countryName'
-
-const Address4 = ipAddress.Address4
-const Address6 = ipAddress.Address6
 
 function isLeafNode(nodeLabel, data) {
   for (let i=0; i<data.labels.length; i++) {
@@ -17,59 +12,47 @@ function isLeafNode(nodeLabel, data) {
 export default function treemapClicked(event) {
   if (event.points && event.points.length) {
     const network = event.points[0].label
-    if (typeof network === 'string') {
-      let prefixMatch
-      try {
-        prefixMatch = (new Address4(network)).isCorrect()
-      } catch (e) {
-        prefixMatch = null
-      }
-      if (!prefixMatch) {
-        try {
-          prefixMatch = (new Address6(network)).isCorrect()
-        } catch (e) {
-          prefixMatch = null
-        }
-      }
-      const domainRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/
-      const domainMatch = domainRegex.exec(network)
-      if (prefixMatch && isLeafNode(network, event.points[0].data)) {
-        const [host, prefixLength] = network.split('/')
-        if (prefixLength) {
-          event.router.push(Tr.i18nRoute({
-            name: 'prefix',
-            params: { ip: host, length: prefixLength },
-          }))
-        }
-      } else if (network.split(' ')[0] in isoCountries && isLeafNode(network.split(' ')[0], event.points[0].data)) {
-        event.router.push(Tr.i18nRoute({
-          name: 'country',
-          params: { cc: network.split(' ')[0] },
-        }))
-      } else if (domainMatch && isLeafNode(network, event.points[0].data)) {
-        event.router.push(Tr.i18nRoute({
-          name: 'hostname',
-          params: { hostname: network },
-        }))
-      } else if (Number(network.replace('AS', '')) && isLeafNode(network, event.points[0].data)) {
-        event.router.push(Tr.i18nRoute({
-          name: 'network',
-          params: { id: network },
-        }))
-      }
-    } else if (typeof network === 'object') {
-      if ('low' in network && isLeafNode(network.low, event.points[0].data)) {
-        const asId = `AS${network.low}`
-        event.router.push(Tr.i18nRoute({
-          name: 'network',
-          params: { id: asId },
-        }))
-      }
-    } else if (typeof network === 'number' && isLeafNode(network, event.points[0].data)) {
+    if (typeof network === 'string' && event.leafKey === 'nameserver'  && isLeafNode(network, event.points[0].data)) {
+    
+    } else if (typeof network === 'number' && event.leafKey === 'asn' && isLeafNode(network, event.points[0].data)) {
       const asId = `AS${network}`
       event.router.push(Tr.i18nRoute({
         name: 'network',
         params: { id: asId },
+      }))
+    } else if (typeof network === 'string' && event.leafKey === 'ixpName'  && isLeafNode(network, event.points[0].data)) {
+
+    } else if (typeof network === 'string' && event.leafKey === 'prefix' && isLeafNode(network, event.points[0].data)) {
+      const [host, prefixLength] = network.split('/')
+      if (prefixLength) {
+        event.router.push(Tr.i18nRoute({
+          name: 'prefix',
+          params: { ip: host, length: prefixLength },
+        }))
+      }
+    } else if (typeof network === 'string' && event.leafKey === 'hostname' & isLeafNode(network, event.points[0].data)) {
+      event.router.push(Tr.i18nRoute({
+        name: 'hostname',
+        params: { hostname: network },
+      }))
+    } else if (typeof network === 'number' && event.leafKey === 'atlasId'  && isLeafNode(network, event.points[0].data)) {
+
+    } else if (typeof network === 'string' && event.leafKey === 'rankName' && isLeafNode(network, event.points[0].data)) {
+      event.router.push(Tr.i18nRoute({
+        name: 'rank',
+        params: { rank: network },
+      }))
+    } else if (typeof network === 'string' && event.leafKey === 'asn' && isLeafNode(network.split(' ')[0], event.points[0].data)) {
+      event.router.push(Tr.i18nRoute({
+        name: 'network',
+        params: { id: network },
+      }))
+    } else if (typeof network === 'string' && event.leafKey === 'ip' && isLeafNode(network, event.points[0].data)) {
+
+    } else if (typeof network === 'string' && event.leafKey === 'country' && isLeafNode(network, event.points[0].data)) {
+      event.router.push(Tr.i18nRoute({
+        name: 'country',
+        params: { cc: network },
       }))
     }
   }


### PR DESCRIPTION
## Description

This PR follows up on issue #811. Navigation is now activated only for leaf nodes. Clicking on a parent node zooms in/out.

## How Has This Been Tested?

Here's a corrected version of the text:

I tested it locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
