### PR TITLE
Fix display bug in ranking widget on network page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ihr-website",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/charts/IypGenericIndicatorsChart.vue
+++ b/src/components/charts/IypGenericIndicatorsChart.vue
@@ -46,6 +46,27 @@ const formatChartData = (arrayOfObjects) => {
         domain: { x: [0, 0.5], y: [0.5, 1] },
       },
     ]
+  } else if (arrayOfObjects.length === 2) {
+    data = [
+      {
+        type: 'indicator',
+        mode: 'number',
+        value: arrayOfObjects[0].rank,
+        title: {
+          text: arrayOfObjects[0].name,
+        },
+        domain: { x: [0, 0.5], y: [0.5, 1] },
+      },
+      {
+        type: 'indicator',
+        mode: 'number',
+        value: arrayOfObjects[1].rank,
+        title: {
+          text: arrayOfObjects[1].name,
+        },
+        domain: { x: [0.6, 1], y: [0, 1] },
+      },
+    ]
   } else {
     data = [
       {

--- a/src/components/iyp/as/ASRankings.vue
+++ b/src/components/iyp/as/ASRankings.vue
@@ -12,7 +12,7 @@ const route = useRoute()
 
 const rankings = ref({
   data: [],
-  show: false,
+  show: true,
   loading: true,
   query: 'MATCH (:AS {asn: $asn})-[r:RANK]->(s:Ranking) RETURN r.rank AS rank, s.name AS name ORDER BY rank',
   columns: [
@@ -29,6 +29,20 @@ const load = () => {
     results => {
       rankings.value.data = results[0]
       rankings.value.loading = false
+      results[0].sort((a, b) => a.rank - b.rank)
+      if (results[0].length == 1) {
+        if (results[0][0].rank > 100) {
+          rankings.value.show = false
+        }
+      } else if (results[0].length == 2) {
+        if (results[0][0].rank > 100 && results[0][1].rank > 100) {
+          rankings.value.show = false
+        }
+      } else {
+        if (results[0][0].rank > 100 && results[0][1].rank > 100 && results[0][2].rank > 100) {
+          rankings.value.show = false
+        }
+      }
     }
   )
 }
@@ -48,10 +62,10 @@ onMounted(() => {
     :columns="rankings.columns"
     :loading-status="rankings.loading"
     :cypher-query="rankings.query.replace(/\$(.*?)}/, `${asNumber}}`)"
-    :slot-length="1"
+    :slot-length="rankings.show ? 1 : 0"
   >
     <IypGenericIndicatorsChart
-      v-if="rankings.data.length > 0" :chart-data="rankings.data"
+      v-if="rankings.data.length > 0 && rankings.show" :chart-data="rankings.data"
     />
   </IypGenericTable>
 </template>


### PR DESCRIPTION
## Description

This PR solves the bug which described in #821.

## Motivation and Context

We want to show rank that are lower than a certain value (100). If any of the displayed value in the chart is under the certain value then the ranking doesn't mean much. In that case we redirect to 'data' tab from the 'chart' tab.

## How Has This Been Tested?

This tested using the following ASs:

1. AS2497
2. AS15169
3. AS2501
4. AS131160

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/19145ef8-95f9-4a5a-8d2b-0bf2c7c89bde)

![image](https://github.com/user-attachments/assets/ee1a7e33-348a-4980-b54c-e39dee81739b)

![image](https://github.com/user-attachments/assets/f80446f2-6b63-41bc-a7f8-1b89baf93e07)

![image](https://github.com/user-attachments/assets/8644750b-cc5f-4af6-b454-90cd13563498)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
