### PR TITLE
Fix bugs from #828

### DIFF
--- a/src/components/charts/BGPLineChart.vue
+++ b/src/components/charts/BGPLineChart.vue
@@ -187,6 +187,10 @@ const adjustQSliderWidth = (relayout) => {
 }
 
 const init = async () => {
+  if (props.rawMessages.length == 1) {
+    minTimestamp.value = Infinity
+    maxTimestamp.value = -Infinity
+  }
   if (props.rawMessages && props.rawMessages.length > 0) {
 		updateTimeRange(props.rawMessages.at(-1).floor_timestamp)
     const { dates, announcementsTrace, withdrawalsTrace } = await generateLineChartData(props.rawMessages.at(-1))

--- a/src/components/charts/BGPPathsChart.vue
+++ b/src/components/charts/BGPPathsChart.vue
@@ -147,7 +147,7 @@ onMounted(() => {
 		<ReactiveChart
 			:layout="actualChartLayout"
 			:traces="actualChartData"
-			:chart-title="actualChartLayout && actualChartLayout.title"
+			:newPlot="true"
 		/>
 	</div>
 	<div v-else class="noData">

--- a/src/components/tables/BGPMessagesTable.vue
+++ b/src/components/tables/BGPMessagesTable.vue
@@ -106,6 +106,10 @@ const rows = computed(() =>
   }))
 )
 
+watch(() => props.selectedPeers, () => {
+  selectedPeersModel.value = props.selectedPeers
+})
+
 watch(selectedPeersModel, () => {
   emit('update-selected-peers', selectedPeersModel.value)
 })


### PR DESCRIPTION
## Description

This PR solves the following bugs:

1. The reset function is not clearing the link chart data, even after changing the input parameters
2. The selected peers in the table are not functioning correctly
3. The newPlot prop in the the BGPPathsChart.vue is not set to true

## How Has This Been Tested?

Tested locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
