### PR TITLE
Fix: Issue #864 Clear "No Data Available" message 

### DIFF
--- a/src/plugins/commonTable.js
+++ b/src/plugins/commonTable.js
@@ -51,10 +51,13 @@ export default function commonTable(props, ctx) {
   })
   watch(rows, (newValue) => {
     filteredRows.value = newValue
-  })
-  watch(filter, (newValue) => {
-    filterTable.value = newValue
-  })
+    // Force a re-render even if filteredRows didn't technically change
+    nextTick(() => { 
+        if (ctx.emit && ctx.emit.filteredRows) {
+            ctx.emit('filteredRows', [filterTable.value, newValue])
+        }
+    });
+})
   return {
     filteredRows,
     filterTable,


### PR DESCRIPTION
## Description

This PR addresses an issue where the "No Data Available" message on the AS Hegemony chart would persist even after switching to a timeframe with data.

Changes:

- Added a nextTick callback inside the rows watcher in commonTable.js. This ensures the filteredRows event triggers after the DOM update finishes, even if the filteredRows array itself hasn't actually changed. Doing this ensures that the chart redraws properly and that any messages get cleared as they should.

## Related issue

Fixes #864