### PR TITLE
Fixed the Navigation Links

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -780,22 +780,22 @@
       "title": "Analysis modules",
       "asInterdependence": {
         "title": "AS Dependency",
-        "docHash": "#AS_dependency",
+        "docHash": "#AS-dependency",
         "description": "Networks connected to the Internet inherently rely on other networks to reach the rest of the world. The Internet Health Report quantifies the inter-dependency of networks using global routing information (BGP), hence improving our understanding of network connectivity and resiliency."
       },
       "networkDelay": {
         "title": "Network Delay",
-        "docHash": "#Network_delay",
+        "docHash": "#Network-delay",
         "description": "Delay is a key metric when assessing the performance or conditions of a network. The Internet Health Report infers network delays between ASes, cities, and Internet landmarks from traceroute data."
       },
       "delayAndForwarding": {
         "title": "Link Monitoring",
-        "docHash": "#Delay_and_forwarding_anomalies",
+        "docHash": "#Delay-and-forwarding-anomalies",
         "description": "Network congestion is another key indicator of network conditions. The Internet Health Report pinpoints link congestion and abnormal forwarding patterns using traceroute data."
       },
       "disco": {
         "title": "Disconnection",
-        "docHash": "#Network_disconnections",
+        "docHash": "#Network-disconnections",
         "description": "The worst-case scenario is the complete disconnection of a network from the Internet. The Internet Health Report infers data plane disruptions by monitoring the connectivity of RIPE Atlas probes."
       }
     },

--- a/src/i18n/locales/jp.json
+++ b/src/i18n/locales/jp.json
@@ -780,22 +780,22 @@
       "title": "Analysis modules",
       "asInterdependence": {
         "title": "AS Dependency",
-        "docHash": "#AS_dependency",
+        "docHash": "#AS-dependency",
         "description": "Networks connected to the Internet inherently rely on other networks to reach the rest of the world. The Internet Health Report quantifies the inter-dependency of networks using global routing information (BGP), hence improving our understanding of network connectivity and resiliency."
       },
       "networkDelay": {
         "title": "Network Delay",
-        "docHash": "#Network_delay",
+        "docHash": "#Network-delay",
         "description": "Delay is a key metric when assessing the performance or conditions of a network. The Internet Health Report infers network delays between ASes, cities, and Internet landmarks from traceroute data."
       },
       "delayAndForwarding": {
         "title": "Link Monitoring",
-        "docHash": "#Delay_and_forwarding_anomalies",
+        "docHash": "#Delay-and-forwarding-anomalies",
         "description": "Network congestion is another key indicator of network conditions. The Internet Health Report pinpoints link congestion and abnormal forwarding patterns using traceroute data."
       },
       "disco": {
         "title": "Disconnection",
-        "docHash": "#Network_disconnections",
+        "docHash": "#Network-disconnections",
         "description": "The worst-case scenario is the complete disconnection of a network from the Internet. The Internet Health Report infers data plane disruptions by monitoring the connectivity of RIPE Atlas probes."
       }
     },


### PR DESCRIPTION
Fixes - #885 

Fixed the navigation link to correctly match the id of the corresponding section of the documentation page.
