### PR TITLE
fix: enable search for ASNs below 100

### DIFF
--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -83,7 +83,8 @@ let loadingQueryRanks = false
 const search = async (value, update) => {
   loading.value = true
   options.value = []
-  const asnRegex = /^(as)?(\d+)$/i
+  // Detect if input is AS followed by a number
+  const asnRegex = /^AS(\d+)$/i
   const asnMatch = asnRegex.exec(value)
   let prefixMatch
   try {
@@ -99,8 +100,9 @@ const search = async (value, update) => {
     }
   }
   if (asnMatch) {
+    // If input is AS followed by a number, search for ASNs
     loadingQueryAS = true
-    queryAS(asnMatch.input).then((res) => {
+    queryAS(asnMatch[1]).then((res) => {
       searchResponse(res, update)
       loadingQueryAS = false
       noResults(res, update)
@@ -113,6 +115,7 @@ const search = async (value, update) => {
       noResults(res, update)
     })
   } else {
+    // General search for AS names, IXPs, prefixes, countries, etc.
     mixedEntitySearch(value, update)
   }
 }
@@ -194,6 +197,7 @@ const queryAS = async (asn) => {
   const res = await iyp_api.run([{ statement: query, parameters: { asn: asn } }])
   return res[0]
 }
+
 
 const queryPrefixes = async (value) => {
   if (props.noPrefix) {
@@ -317,12 +321,19 @@ const optimizeSearchResults = (res) => {
 
 const filter = (value, update, abort) => {
   activateSearch.value = true
-  if (value.length < MIN_CHARACTERS) {
+  if (value.length === 0) {
     abort()
-  } else {
-    search(value, update)
+    return
   }
+
+  const asnRegex = /^AS(\d+)$/i
+  if (value.length < MIN_CHARACTERS && !asnRegex.test(value)) {
+    abort()
+    return
+  }
+  search(value, update)
 }
+
 
 const paramExists = (param) => {
   const params = route.params


### PR DESCRIPTION
## Description
This PR fixes the issue where ASNs with fewer than three characters (e.g., `AS16`, `AS99`) were not returning results due to the minimum character requirement in the search bar. The updated logic ensures:
- If the input starts with `AS` followed by a number, it directly searches for ASNs.
- Rest searches  are still handled as general searches.


This fix ensures that all ASNs, regardless of their number length, return relevant results.

## Related issue
Fixes  #893 


## How Has This Been Tested?
- Tested with inputs like `AS16`, `AS99`, `AS163`, and `AS2497` to confirm ASN results appear.
- Verified that searches for IP addresses, prefixes, IXPs, and other entities remain unaffected.

## Screenshots (if appropriate)
<img width="690" alt="Screenshot 2025-02-05 at 6 44 50 PM" src="https://github.com/user-attachments/assets/202d412a-5835-4e24-9457-9fe7a1c6bdd9" />
<img width="655" alt="Screenshot 2025-02-05 at 6 45 42 PM" src="https://github.com/user-attachments/assets/50c7f3a1-7ca1-4205-9ebf-6df1abf85318" />
<img width="677" alt="Screenshot 2025-02-05 at 6 44 56 PM" src="https://github.com/user-attachments/assets/e57bf120-eb2b-4b21-893e-ae8fa8db9b1d" />

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

