### PR TITLE
fix: correct 'Upstream' ASes subcaption

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -928,7 +928,7 @@
       },
       "upstreams": {
         "title": "''Upstream'' ASes",
-        "caption": "ASes depending on AS",
+        "caption": "Network dependency of AS",
         "info": {
           "title": "''Upstream'' ASes",
           "description": "<p>ASes that are usually seen upstream of the selected network in BGP data. Values close to 100% mean that the AS is seen in all, or at least most, of the AS paths to the selected AS.</p><p>See also <a href='/ihr/en/documentation#AS-dependency'>AS Dependency documentation</a>.</p>"

--- a/src/i18n/locales/jp.json
+++ b/src/i18n/locales/jp.json
@@ -928,7 +928,7 @@
       },
       "upstreams": {
         "title": "''Upstream'' ASes",
-        "caption": "ASes depending on AS",
+        "caption": "Network dependency of AS",
         "info": {
           "title": "''Upstream'' ASes",
           "description": "<p>ASes that are usually seen upstream of the selected network in BGP data. Values close to 100% mean that the AS is seen in all, or at least most, of the AS paths to the selected AS.</p><p>See also <a href='/ihr/en/documentation#AS-dependency'>AS Dependency documentation</a>.</p>"

--- a/src/i18n/locales/jp.json
+++ b/src/i18n/locales/jp.json
@@ -928,7 +928,7 @@
       },
       "upstreams": {
         "title": "''Upstream'' ASes",
-        "caption": "Network dependency of AS",
+        "caption": "ASes depending on AS",
         "info": {
           "title": "''Upstream'' ASes",
           "description": "<p>ASes that are usually seen upstream of the selected network in BGP data. Values close to 100% mean that the AS is seen in all, or at least most, of the AS paths to the selected AS.</p><p>See also <a href='/ihr/en/documentation#AS-dependency'>AS Dependency documentation</a>.</p>"


### PR DESCRIPTION


## Description
Changed text from 'ASes depending on AS' to 'Network dependency of AS'

## Related issue

<!--- Replace only the '000' with the issue number. -->
<!--- Do not include a URL. -->

#897 


## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/df916b92-ef1c-4876-b4cb-9a83b8c50432)


## Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
