### PR TITLE
Added color contrast to the active option in dropdown menu of navbar

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -342,7 +342,7 @@ watch(simpleMenu, () => {
   height: 50px;
 }
 .IHR_active-route {
-  background: rgba(255, 255, 255, 0.15) !important;
+  background: #ffffff26 !important;
   border-radius: 4px;
 }
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -215,7 +215,7 @@ watch(simpleMenu, () => {
                   v-close-popup
                   clickable
                   :to="Tr.i18nRoute({ name: option.routeName })"
-                  active-class="text-grey"
+                  active-class="IHR_active-route"
                   @click="closeMenu"
                 >
                   <QItemSection>
@@ -269,13 +269,14 @@ watch(simpleMenu, () => {
             style="font-size: 16px;"
             header-class="text-white text-uppercase text-weight-medium q-py-md"
           >
-            <!-- Submenu items -->
+            <!-- Submenu items -->  
             <QList padding>
               <QItem
                 v-for="option in item.options"
                 :key="option.entryName"
                 clickable
                 :to="Tr.i18nRoute({ name: option.routeName })"
+                active-class="IHR_active-route"
                 @click="leftDrawerOpen = false"
                 style="padding: 12px 24px;"
               >
@@ -339,6 +340,10 @@ watch(simpleMenu, () => {
 }
 #IHR_last-element {
   height: 50px;
+}
+.IHR_active-route {
+  background: rgba(255, 255, 255, 0.15) !important;
+  border-radius: 4px;
 }
 
 @media screen and (max-width: 1024px) {


### PR DESCRIPTION
## Description

Added a background-color `#ffffff26` to show the active option inside the dropdown menu of navbar separately.
Fixed the grey color of main text of that active option for better visibility.

## Related issue

#899 

## How Has This Been Tested?
I have tested the changes locally.

## Screenshots (if appropriate):

![Screenshot from 2025-02-14 08-12-04](https://github.com/user-attachments/assets/5b605340-5268-4608-a640-13b189fa2057)

![Screenshot from 2025-02-14 08-15-17](https://github.com/user-attachments/assets/7e69280a-31ef-4c17-99e0-65632f451fb1)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
