### PR TITLE
bug: remove horizontal scrollbar on Plotly icon hover

### DIFF
--- a/src/components/maps/WorldMap.vue
+++ b/src/components/maps/WorldMap.vue
@@ -82,6 +82,7 @@ const onCountryClick = (eventData) => {
 <style scoped>
 .map-container {
   width: 100%;
+  overflow: hidden;
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Do not include backticks (`) in the Title above.  -->

## Description
Adjusted CSS in the modal to prevent unwanted scrolling when hovering over the Plotly icon.

## Related issue

#905 

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/64b3bcd4-3de1-4ba5-8597-fb0fa16cf89b)


## Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
