### PR TITLE
Added trim function to remove leading or tailing white spaces in the searched term before searching

### DIFF
--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -81,7 +81,6 @@ let loadingQueryTags = false
 let loadingQueryRanks = false
 
 const search = async (value, update) => {
-  value = value.trim()
   loading.value = true
   options.value = []
   const asnRegex = /^as(\d+)$/i
@@ -317,12 +316,11 @@ const optimizeSearchResults = (res) => {
 }
 
 const filter = (value, update, abort) => {
-  value = value.trim()
   activateSearch.value = true
   if (value.length < MIN_CHARACTERS) {
     abort()
   } else {
-    search(value, update)
+    search(value.trim(), update)
   }
 }
 

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -81,6 +81,7 @@ let loadingQueryTags = false
 let loadingQueryRanks = false
 
 const search = async (value, update) => {
+  value = value.trim()
   loading.value = true
   options.value = []
   const asnRegex = /^as(\d+)$/i
@@ -316,6 +317,7 @@ const optimizeSearchResults = (res) => {
 }
 
 const filter = (value, update, abort) => {
+  value = value.trim()
   activateSearch.value = true
   if (value.length < MIN_CHARACTERS) {
     abort()


### PR DESCRIPTION
## Description

Added trim function to remove or strip leading and tailing white spaces in the searched term before start searching.
Added value.trim() in SearchBar.vue
## Related issue

fixed #917 

## How Has This Been Tested?

I have tested all the changes locally.

## Screenshots (if appropriate):

[Screencast from 2025-02-26 13-23-27.webm](https://github.com/user-attachments/assets/644151f6-6d6b-44da-8195-990230ead586)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
