### PR TITLE
Disbaled Searchbar when map overlay is open

### DIFF
--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -67,6 +67,8 @@ const options = ref([{ name: 'Suggestions' }, { label: 2497, value: 2497, name: 
 const model = ref([])
 const loading = ref(false)
 const activateSearch = ref(true)
+const showMapDialog = ref(false)
+const isSearchBarDisabled = ref(false)
 
 const Address4 = ipAddress.Address4
 const Address6 = ipAddress.Address6
@@ -81,6 +83,7 @@ let loadingQueryTags = false
 let loadingQueryRanks = false
 
 const search = async (value, update) => {
+  if (isSearchBarDisabled.value) return
   loading.value = true
   options.value = []
   const asnRegex = /^as(\d+)$/i
@@ -316,6 +319,7 @@ const optimizeSearchResults = (res) => {
 }
 
 const filter = (value, update, abort) => {
+  if (isSearchBarDisabled.value) return
   activateSearch.value = true
   if (value.length < MIN_CHARACTERS) {
     abort()
@@ -445,8 +449,6 @@ const routeToRank = (rank) => {
   )
 }
 
-const showMapDialog = ref(false)
-
 const showMap = () => {
   showMapDialog.value = true
 }
@@ -464,6 +466,10 @@ watch(
     activateSearch.value = false
   }
 )
+
+watch(showMapDialog, (newVal) => {
+  isSearchBarDisabled.value = newVal
+})
 </script>
 
 <template>
@@ -481,12 +487,17 @@ watch(
     :input-class="input"
     hide-selected
     @filter="filter"
+    :disable="isSearchBarDisabled"
   >
     <template #append>
       <div v-if="!props.noCountry" @click="showMap">
         <QBtn :color="label" icon="fas fa-map" flat dense />
-        <QDialog v-model="showMapDialog">
-          <WorldMap @country-selected="handleCountryClicked" />
+        <QDialog 
+          v-model="showMapDialog" 
+          @show="isSearchBarDisabled = true" 
+          @hide="isSearchBarDisabled = false"
+        >
+            <WorldMap @country-selected="handleCountryClicked" />
         </QDialog>
       </div>
       <div>

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -83,7 +83,6 @@ let loadingQueryTags = false
 let loadingQueryRanks = false
 
 const search = async (value, update) => {
-  if (isSearchBarDisabled.value) return
   loading.value = true
   options.value = []
   const asnRegex = /^as(\d+)$/i

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -497,7 +497,7 @@ watch(showMapDialog, (newVal) => {
           @show="isSearchBarDisabled = true" 
           @hide="isSearchBarDisabled = false"
         >
-            <WorldMap @country-selected="handleCountryClicked" />
+          <WorldMap @country-selected="handleCountryClicked" />
         </QDialog>
       </div>
       <div>


### PR DESCRIPTION
## Description
Made the search bar disabled when the map overlay is open.
added a state variable isSearchBarDisabled to control the search bar.

## Related issue

fixed #916 

## How Has This Been Tested?

I have tested all the changes locally

## Screenshots (if appropriate):

[Screencast from 2025-02-27 08-47-03.webm](https://github.com/user-attachments/assets/9d9af2da-8431-4a8e-b9f8-4336a24b5cc9)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
