### PR TITLE
 Replace triangular loader with blue circular spinner

### DIFF
--- a/src/components/charts/PrefixHegemonyChart.vue
+++ b/src/components/charts/PrefixHegemonyChart.vue
@@ -523,25 +523,46 @@ watch(
       </QTabs>
       <QTabPanels v-model="details.activeTab" animated>
         <QTabPanel name="routes">
-          <PrefixHegemonyTable
-            :data="prefixHegemonyData"
-            :loading="loading"
-            :show-country="countryCode == null"
-          />
+          <template v-if="loading">
+            <div class="spinner-container">
+              <q-spinner color="secondary" size="50px" />
+            </div>
+          </template>
+          <template v-else>
+            <PrefixHegemonyTable
+              :data="prefixHegemonyData"
+              :loading="loading"
+              :show-country="countryCode == null"
+            />
+          </template>
         </QTabPanel>
         <QTabPanel name="origins">
-          <PrefixHegemonyTableStats
-            :data="prefixHegemonyDataOrigins"
-            :loading="loading"
-            :column-name="selection.label"
-          />
+          <template v-if="loading">
+            <div class="spinner-container">
+              <q-spinner color="secondary" size="50px" />
+            </div>
+          </template>
+          <template v-else>
+            <PrefixHegemonyTableStats
+              :data="prefixHegemonyDataOrigins"
+              :loading="loading"
+              :column-name="selection.label"
+            />
+          </template>
         </QTabPanel>
         <QTabPanel name="transits">
-          <PrefixHegemonyTableStats
-            :data="prefixHegemonyDataTransits"
-            :loading="loading"
-            :column-name="selection.label"
-          />
+          <template v-if="loading">
+            <div class="spinner-container">
+              <q-spinner color="secondary" size="50px" />
+            </div>
+          </template>
+          <template v-else>
+            <PrefixHegemonyTableStats
+              :data="prefixHegemonyDataTransits"
+              :loading="loading"
+              :column-name="selection.label"
+            />
+          </template>
         </QTabPanel>
         <QTabPanel name="api" class="IHR_api-table q-pa-lg" light>
           <h3>{{ $t('charts.prefixHegemony.table.apiTitle') }}</h3>
@@ -560,4 +581,11 @@ watch(
   </div>
 </template>
 
-<style></style>
+<style>
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100px;
+}
+</style>

--- a/src/components/tables/CountryHegemonyTable.vue
+++ b/src/components/tables/CountryHegemonyTable.vue
@@ -134,6 +134,16 @@ const getClassByHegemony = (hegemony) => {
     binary-state-sort
     flat
   >
+    <template #no-data>
+      <div v-if="loading" class="spinner-container">
+        <q-spinner color="secondary" size="50px" />
+      </div>
+      <div v-else class="q-table__bottom row items-center q-table__bottom--nodata">
+        <QIcon name="warning" class="q-table__bottom-nodata-icon" />
+        No data available
+      </div>
+    </template>
+
     <template #header="props" style="display: contents">
       <QTr>
         <QTh colspan="2">
@@ -200,4 +210,11 @@ const getClassByHegemony = (hegemony) => {
   </QTable>
 </template>
 
-<style></style>
+<style>
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100px;
+}
+</style>

--- a/src/components/tables/CountryHegemonyTable.vue
+++ b/src/components/tables/CountryHegemonyTable.vue
@@ -62,7 +62,7 @@ const columns = ref([
     label: 'Autonomous System Name',
     align: 'left',
     field: (row) => {
-      return row.asn_name == '' ? '--' : row.asn_name
+      return row.asn_name === '' ? '--' : row.asn_name
     },
     format: (val) => `${val}`,
     sortable: true
@@ -134,16 +134,17 @@ const getClassByHegemony = (hegemony) => {
     binary-state-sort
     flat
   >
-    <template #no-data>
-      <div v-if="loading" class="spinner-container">
+    <template #loading>
+      <div class="spinner-container">
         <q-spinner color="secondary" size="50px" />
       </div>
-      <div v-else class="q-table__bottom row items-center q-table__bottom--nodata">
+    </template>
+    <template #no-data>
+      <div v-if="!loading" class="q-table__bottom row items-center q-table__bottom--nodata">
         <QIcon name="warning" class="q-table__bottom-nodata-icon" />
         No data available
       </div>
     </template>
-
     <template #header="props" style="display: contents">
       <QTr>
         <QTh colspan="2">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Do not include backticks (`) in the Title above.  -->

## Description

Replaced the default triangular loader in PrefixHegemonyChart.vue and CountryHegemonyTable.vue with the blue circular spinner to maintain UI consistency across the site. Updated the corresponding CSS and markup without affecting functionality.

## Related issue

<!--- Replace only the '000' with the issue number. -->
<!--- Do not include a URL. -->

#921 

## Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
