### PR TITLE
Fix duplicate get probe by id api calls in traceroute visualizer

### DIFF
--- a/src/components/TracerouteMonitor.vue
+++ b/src/components/TracerouteMonitor.vue
@@ -91,8 +91,8 @@ const processData = async (tracerouteData, loadProbes = false) => {
         (!props.probeIDs ||
           props.probeIDs.length === 0 ||
           props.probeIDs.includes(probeData.prb_id.toString())) &&
-        !allProbes.value.includes(probeData.prb_id)
-      ) {
+          !allProbes.value.includes(probeData.prb_id.toString())
+          ) {
         allProbes.value.push(probeData.prb_id.toString())
         selectedProbes.value.push(probeData.prb_id.toString())
         atlas_api.getProbeById(probeData.prb_id.toString()).then((data) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Do not include backticks (`) in the Title above.  -->

## Description

<!--- Describe your changes in detail. -->
In this PR, I have fixed an includes check over allProbes array ref. 
The probeData.prb_id is a number and the code stores it in allProbes array as a string. 
So, while checking if the probe_id exists in allProbes array, we need to convert it to string first while comparing. 

<!--- Why is this change required? What problem does it solve? -->
TracerouteMonitor component was storing duplicate probe ids in this ref: allProbes. 
Expected behavior is to skip adding the probe id in the allProbes array. 

Problem it solves is: 
In this if block, there is an API call to RIPE Atlas to fetch the probe by ID. Since the bug allowed duplicate probe ids, the API requests were also made for duplicate probe ids. Which are redundant calls. 

<!--- Do not include backticks (`).  -->

## Related issue

<!--- Replace only the '000' with the issue number. -->
<!--- Do not include a URL. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to. -->
I observed this traceroute: [75404443](https://atlas.ripe.net/measurements/75404443). 
Total 19 probes reached the target. Since, it should fetch only 19  probes data. So, it should only call 19 times to the https://atlas.ripe.net/api/v2/probes/ endpoint. 

### Tools used for testing: 
Chrome devtool's network tab and console. 

### Testing strategy
1) Observe this behavior on the IHR live website. Result: 49 requests for 19 probes.
2) Check if the fix works in the local implementation. Result: 19 requests for 19 probes.


### Before fix: 49 requests for 19 probes (duplicate requests)
![image](https://github.com/user-attachments/assets/d15b7e26-0066-435f-9947-7a21c03c32e4)

### After fix: 19 requests for 19 probes. (1 request for 1 probe)
![image](https://github.com/user-attachments/assets/3e94e442-5b4e-409e-8ac0-9fa9a6abcb37)

<!--- see how your change affects other areas of the code, etc. -->
### Affected areas
This ref is used as a prop in TracerouteProbesTable. 
In this component, there's a computed ref called paginatedProbes, in which there's a set variable called uniqueProbes. It makes sure that a probe is not duplicated by adding from allProbes array into uniqueProbes set. 
Since, I have removed the duplicates from the source itself, this Set is not required. 
TracerouteProbesTable is only used by TracerouteMonitor component. 

<!--- Do not include backticks (`).  -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
