### PR TITLE
Fix duplicate api calls in traceroute visualizer #941

### DIFF
--- a/src/components/TracerouteMonitor.vue
+++ b/src/components/TracerouteMonitor.vue
@@ -91,8 +91,8 @@ const processData = async (tracerouteData, loadProbes = false) => {
         (!props.probeIDs ||
           props.probeIDs.length === 0 ||
           props.probeIDs.includes(probeData.prb_id.toString())) &&
-        !allProbes.value.includes(probeData.prb_id)
-      ) {
+          !allProbes.value.includes(probeData.prb_id.toString())
+          ) {
         allProbes.value.push(probeData.prb_id.toString())
         selectedProbes.value.push(probeData.prb_id.toString())
         atlas_api.getProbeById(probeData.prb_id.toString()).then((data) => {

--- a/src/components/TracerouteMonitor.vue
+++ b/src/components/TracerouteMonitor.vue
@@ -52,6 +52,7 @@ const rttOverTime = ref([])
 const intervalValue = ref(null)
 const loadMeasurementErrorDialog = ref(false)
 const loadMeasurementErrorMessage = ref('')
+const nodeSet = ref(new Set())
 
 const handleLoadMeasurementError = (error) => {
   loadMeasurementErrorMessage.value = error.message || 'An unexpected error occurred.'
@@ -145,7 +146,8 @@ const processData = async (tracerouteData, loadProbes = false) => {
           asn: nodeInfo.asn || 'unknown'
         }
 
-        if (!newNodeInfo.isNonResponsive) {
+        if (!newNodeInfo.isNonResponsive && !nodeSet.value.has(newNodeInfo.label)) {
+          nodeSet.value.add(newNodeInfo.label)
           const asnPromise = RipeApi.userASN(newNodeInfo.label).then((asnData) => {
             const asn = asnData.data.data.asns[0]
             if (asn) {

--- a/src/components/tables/TracerouteProbesTable.vue
+++ b/src/components/tables/TracerouteProbesTable.vue
@@ -25,15 +25,12 @@ const selectedProbesModel = ref(props.selectedProbes)
 
 const paginatedProbes = computed(() => {
   const query = searchQuery.value.toLowerCase()
-  const uniqueProbes = new Set()
   return props.allProbes
     .map((probe) => ({
       probe,
       ...props.probeDetailsMap[probe]
     }))
     .filter((probe) => {
-      if (uniqueProbes.has(probe.probe)) return false
-      uniqueProbes.add(probe.probe)
       return ['address_v4', 'address_v6', 'country_code', 'asn_v4', 'asn_v6'].some((field) => {
         return probe[field] && probe[field].toString().toLowerCase().includes(query)
       })


### PR DESCRIPTION
## Description

In this PR: 
1. Fix duplicate get probe by id rest API calls (https://atlas.ripe.net/api/v2/<probe_id>)
2. Fix duplicate userASN by ip address API calls (https://stat.ripe.net/data/network-info/data.json?resource=<ip_address>)

### To fix duplicate get probe by id rest API calls
I corrected an includes check over allProbes array ref. 
The probeData.prb_id is a number and the code stores it in allProbes array as a string. 
So, while checking if the probe_id exists in allProbes array, we need to convert it to string first while comparing. 

### To fix duplicate userASN by ip address API calls
I defined a ref **nodeSet** with an empty set in the TracerouteMonitor component. Added check whether nodeSet already includes the ip address or not. 
- If nodeSet does not includes the ip address yet, then it should include it and should make the API request to fetch the node details. 
- Else, it should not make the API call. 

Reason to define a new ref **nodeSet**: 
This ref tracks the ip addresses which have been traversed already. The same detail might be present in the **ipToAsnMap** map. However, the ipToAsnMap will only get populated after the userASN by ip address requests. Therefore, it should not be used in this case where we need to decide whether to make the request or not. 

### Root cause
The TracerouteMonitor component can encounter same probe and same node while traversing the measrementData response array. Also, In each encounter, the component was making an API request to fetch the probe and nodes details without checking if it was already sent to  fetch its data or not. 
- The implementation for checking probe requests has a mistake in type casting. 
- There is no implementation for checking if a node's ip address is already used to fetch details of the node. 

Therefore, there were thousands of API requests observed for only around 800 nodes and  only 19 probes. 
Hence, I made the fix to call the API only when it is not requested yet. 
If a call is already made for a probe and node, then do not make another API call for the same. 

## Related issue
#942

## How Has This Been Tested?
I observed this traceroute: [75404443](https://atlas.ripe.net/measurements/75404443). 
Total 19 probes reached the target. So, it should call only 19 times with different probe ids to the https://atlas.ripe.net/api/v2/probes/<prob_id> endpoint. 
Also, there are only 778 nodes.  So, it should call only 778 times with different ip addresses to the https://stat.ripe.net/data/network-info/data.json?resource=<ip_address> endpoint. 

### Tools used for testing: 
Chrome devtool's network tab and console. 

### Testing strategy
1) Before fix: Observe this behavior on the IHR live website. Result: 49 requests for 19 probes, 3798 requests for 778 nodes. 
2) Check if the fix works in the local implementation. Result: 19 requests for 19 probes. 778 requests for 778 nodes. 

### Before fix: 49 requests for 19 probes (duplicate requests)
![image](https://github.com/user-attachments/assets/d15b7e26-0066-435f-9947-7a21c03c32e4)

### After fix: 19 requests for 19 probes. (1 request for 1 probe)
![image](https://github.com/user-attachments/assets/3e94e442-5b4e-409e-8ac0-9fa9a6abcb37)

### Before fix: 3798 requests for 778 nodes (duplicate requests)
![image](https://github.com/user-attachments/assets/5f19b99b-b8bd-4a22-bf12-ec6c9ed6ede8)

### After fix: 778 requests for 778 nodes (1 request for 1 node)
![image](https://github.com/user-attachments/assets/19ec4a54-2a1e-42d1-962f-43a41164366b)

### Affected areas
This ref allProbes is used as a prop in TracerouteProbesTable. 
In this component, there's a computed ref called paginatedProbes, in which there's a set variable called **uniqueProbes**. It makes sure that a probe is not duplicated by adding from allProbes array into uniqueProbes set. 
Since, I have removed the duplicates from the source itself, this Set is not required now. 
TracerouteProbesTable is only used by TracerouteMonitor component. So, there is no other  possibilities that TracerouteProbesTable will receive duplicate probes in allProbes prop. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
