### PR TITLE
Fix: topology chart deletion

### DIFF
--- a/src/views/NetworkTopology.vue
+++ b/src/views/NetworkTopology.vue
@@ -29,13 +29,10 @@ const incrementChart = (searchInput, af, fromLink = false) => {
 }
 
 const pushRoute = (searchInput, af) => {
-  let query = null
-  if (searchInput !== '[]') {
-    query = Object.assign({}, route.query, {
-      input: searchInput,
-      af: af
-    })
-  }
+  let query = Object.assign({}, route.query, {
+    input: searchInput,
+    af: af
+  })
   router.push(
     Tr.i18nRoute({
       replace: true,


### PR DESCRIPTION
## Description

Fixed an issue in the Network Topology view where deleting the second empty chart would cause the entire layout to collapse. The bug was caused by inconsistent handling of empty arrays in the route query parameters.

The fix ensures that route query parameters (input and af) are always maintained in the route, regardless of whether the charts are empty or not. This creates consistent behavior when managing empty charts and keeps the layout stable during deletion operations. 

Implementation details:
- Modified the (pushRoute) function to always maintain query parameters
- Simplified the route update logic for more consistent behavior

## Related issue

#948 

## How Has This Been Tested?

1. Created multiple empty charts (2 and 4) to verify consistent behavior
2. Deleted charts in different orders to ensure layout stability
3. Verified route query parameters are maintained correctly
4. Tested layout preservation with empty charts
5. Verified that both (input and af) parameters remain in the route

## Screenshots:
Here's a video for clarification:

https://github.com/user-attachments/assets/dfd5ac70-ea9c-4471-8537-3300d1e57e9d

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
