### PR TITLE
Made Time graph containers responsive

### DIFF
--- a/src/components/controllers/AggregatedAlarmsController.vue
+++ b/src/components/controllers/AggregatedAlarmsController.vue
@@ -656,8 +656,8 @@ watch(selectedAlarmTypesOptions.value, () => {
         </div>
       </QCardSection>
     </QCard>
-    <div class="row">
-      <div class="col q-mr-md">
+    <div class="row q-col-gutter-md">
+      <div class="col-12 col-md-6">
         <QCard class="card">
           <QCardSection>
             <div class="row alarm-actions items-center">
@@ -701,7 +701,7 @@ watch(selectedAlarmTypesOptions.value, () => {
           </QCardSection>
         </QCard>
       </div>
-      <div class="col">
+      <div class="col-12 col-md-6">
         <QCard class="card">
           <QCardSection>
             <div class="col">


### PR DESCRIPTION
## Description
Enhances the responsiveness of the two graph containers—"Alarms over Time" and "Alarms by Severities"—by updating their layout using Quasar's responsive grid system.

## Changes Made
1] Replaced class="col" with class="col-12 col-md-6" on both graph container wrappers to enable responsive.

2] Added q-col-gutter-md to the parent row for proper spacing between containers.

3] Ensured the layout stacks vertically on small screens (mobile) and returns to side-by-side on medium and larger devices.



## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/3ed24cb3-eb50-44a3-853f-b851666aad38)

