### PR TITLE
fix: disable unintentional zooming in network topology view

### DIFF
--- a/src/components/charts/NetworkTopologyChart.vue
+++ b/src/components/charts/NetworkTopologyChart.vue
@@ -92,6 +92,7 @@ const configs = vNG.defineConfigs({
     autoPanAndZoomOnLoad: 'fit-content',
     fitContentMargin: '15%',
     scalingObjects: 'true',
+    zoomEnabled: false, // Disables mouse wheel / pinch zoom
     grid: {
       visible: false,
       interval: 100,
@@ -397,6 +398,7 @@ const eventHandlers = {
     tooltipHoverOpacity.value = 0
   },
   'node:click': ({ node, event }) => {
+
     if (event.detail > 0) {
       if (!props.isComponent) {
         tooltipHoverOpacity.value = 0
@@ -458,6 +460,7 @@ onMounted(() => {
 })
 
 defineExpose({ fitToScreen })
+
 </script>
 
 <template>
@@ -512,6 +515,7 @@ defineExpose({ fitToScreen })
         :layouts="layouts"
         :configs="configs"
         :event-handlers="eventHandlers"
+        :options="graphOptions"
       />
 
       <div v-if="props.showLegend" class="legend">
@@ -555,6 +559,7 @@ defineExpose({ fitToScreen })
     <h5 v-if="!loading && Object.keys(allNodes).length == 0" class="text-center">No data found</h5>
   </QCard>
 </template>
+
 
 <style scoped>
 .graphContainer {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Do not include backticks (`) in the Title above.  -->

## Description

<!--- Describe your changes in detail. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Do not include backticks (`).  -->
Disabled unintended zooming behavior in the network topology view. This prevents users from accidentally zooming in/out when scrolling or interacting with the visualization, improving user experience and navigation stability.

## Related issue

<!--- Replace only the '000' with the issue number. -->
<!--- Do not include a URL. -->

#970 

## How Has This Been Tested?
Tested manually by interacting with the network topology UI:
- Verified that scroll wheel no longer triggers zoom unexpectedly.
- Confirmed that the intended panning/zoom controls still work (if any).
Tested on latest Chrome and Firefox browsers.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to. -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Do not include backticks (`).  -->

## Screenshots (if appropriate):

_N/A_ (no visual UI changes)

## Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
