### PR TITLE
Change IYP queries to have more specific Prefix types

### DIFF
--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -10,9 +10,9 @@ const iyp_api = inject('iyp_api')
 const as_info_query = ref({
   loading: true,
   query: `MATCH (a:AS {asn: $asn})
-      OPTIONAL MATCH (a)-[:ORIGINATE]->(p4:Prefix {af:4})
+      OPTIONAL MATCH (a)-[:ORIGINATE]->(p4:BGPPrefix {af:4})
       WITH COALESCE(COUNT(DISTINCT p4.prefix), 0) AS prefixes_v4, a
-      OPTIONAL MATCH (a)-[:ORIGINATE]->(p6:Prefix {af:6})
+      OPTIONAL MATCH (a)-[:ORIGINATE]->(p6:BGPPrefix {af:6})
       WITH COALESCE(COUNT(DISTINCT p6.prefix), 0) AS prefixes_v6, prefixes_v4, a
       OPTIONAL MATCH (a)-[:NAME {reference_org:'PeeringDB'}]->(pdbn:Name)
       OPTIONAL MATCH (a)-[:NAME {reference_org:'BGP.Tools'}]->(btn:Name)

--- a/src/components/charts/NetworkTopologyChart.vue
+++ b/src/components/charts/NetworkTopologyChart.vue
@@ -72,13 +72,13 @@ const as_topology_query = ref({
 })
 
 const prefix_topology_query = ref({
-  query1: `MATCH (a:AS)-[o:ORIGINATE]-(pfx:Prefix {prefix: $prefix})-[h:DEPENDS_ON {af:$af}]->(d:AS)
+  query1: `MATCH (a:AS)-[o:ORIGINATE]-(pfx:BGPPrefix {prefix: $prefix})-[h:DEPENDS_ON {af:$af}]->(d:AS)
           WITH a, COLLECT(DISTINCT d) AS dependencies, pfx, o
           UNWIND dependencies AS d
           MATCH p = allShortestPaths((a)-[:PEERS_WITH*]-(d))
           WHERE a.asn <> d.asn AND all(r IN relationships(p) WHERE r.af = $af) AND all(n IN nodes(p) WHERE n IN dependencies)
           RETURN p, a, pfx, o`,
-  query2: `MATCH (p:Prefix {prefix: $prefix})
+  query2: `MATCH (p:BGPPrefix {prefix: $prefix})
           OPTIONAL MATCH (p)<-[o:ORIGINATE]-(a:AS)
           OPTIONAL MATCH(p)-[deleg:COUNTRY {reference_name: 'nro.delegated_stats'}]->(c:Country)
           RETURN p.prefix AS prefix, head(collect(DISTINCT(o.descr))) AS Name, c.name AS Country`

--- a/src/components/iyp/as/ASAuthoritativeNameservers.vue
+++ b/src/components/iyp/as/ASAuthoritativeNameservers.vue
@@ -17,7 +17,7 @@ const nameservers = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (:AS {asn: $asn})-[:ORIGINATE]->(p:Prefix)<-[:PART_OF]-(i:IP)<-[:RESOLVES_TO {reference_name:'openintel.infra_ns'}]-(h:AuthoritativeNameServer)
+  query: `MATCH (:AS {asn: $asn})-[:ORIGINATE]->(p:BGPPrefix)<-[:PART_OF]-(i:IP)<-[:RESOLVES_TO {reference_name:'openintel.infra_ns'}]-(h:AuthoritativeNameServer)
     RETURN DISTINCT h.name AS nameserver, COLLECT(DISTINCT p.prefix) AS prefix, i.ip as ip`,
   columns: [
     {

--- a/src/components/iyp/as/ASOriginatedPrefixes.vue
+++ b/src/components/iyp/as/ASOriginatedPrefixes.vue
@@ -18,12 +18,12 @@ const prefixes = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (:AS {asn: $asn})-[o:ORIGINATE]->(p:Prefix)
+  query: `MATCH (:AS {asn: $asn})-[o:ORIGINATE]->(p:BGPPrefix)
     OPTIONAL MATCH (p)-[:COUNTRY {reference_org:'IHR'}]->(c:Country)
     OPTIONAL MATCH (p)-[creg:COUNTRY {reference_org:'NRO'}]->(creg_country:Country)
     OPTIONAL MATCH (p)-[:CATEGORIZED]->(t:Tag)
-    OPTIONAL MATCH (p)-[:PART_OF*1..3]->(cover:Prefix)-[cover_creg:ASSIGNED {reference_org:'NRO'}]->(:OpaqueID)
-    OPTIONAL MATCH (cover:Prefix)-[cover_creg:ASSIGNED {reference_org:'NRO'}]->(cover_creg_country:Country)
+    OPTIONAL MATCH (p)-[:PART_OF*1..3]->(cover:RIRPrefix)-[cover_creg:ASSIGNED {reference_org:'NRO'}]->(:OpaqueID)
+    OPTIONAL MATCH (cover:RIRPrefix)-[cover_creg:ASSIGNED {reference_org:'NRO'}]->(cover_creg_country:Country)
     RETURN c.country_code AS cc, toUpper(COALESCE(creg.registry, cover_creg.registry, '-')) AS rir, toUpper(COALESCE(creg_country.country_code, cover_creg_country.country_code, '-')) AS rir_country, p.prefix as prefix, collect(DISTINCT(t.label)) AS tags, collect(DISTINCT o.descr) as descr, collect(DISTINCT o.visibility) as visibility`,
   columns: [
     {

--- a/src/components/iyp/as/ASPopularDomains.vue
+++ b/src/components/iyp/as/ASPopularDomains.vue
@@ -16,7 +16,7 @@ const domains = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (:AS {asn: $asn})-[:ORIGINATE]->(p:Prefix)<-[:PART_OF]-(:IP)<-[:RESOLVES_TO]-(h:HostName)-[:PART_OF]->(d:DomainName)-[rr:RANK]->(rn:Ranking)
+  query: `MATCH (:AS {asn: $asn})-[:ORIGINATE]->(p:BGPPrefix)<-[:PART_OF]-(:IP)<-[:RESOLVES_TO]-(h:HostName)-[:PART_OF]->(d:DomainName)-[rr:RANK]->(rn:Ranking)
     WHERE rr.rank < 100000 and rr.reference_name = 'tranco.top1m' and h.name = d.name
     RETURN DISTINCT h.name AS hostName, rr.rank AS rank, rn.name AS rankingName, split(h.name, '.')[-1] AS tld, 1/toFloat(rr.rank) AS inv_rank, COLLECT(DISTINCT p.prefix) AS prefix
     ORDER BY rank`,

--- a/src/components/iyp/as/ASPopularHostNames.vue
+++ b/src/components/iyp/as/ASPopularHostNames.vue
@@ -16,7 +16,7 @@ const domains = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (:AS {asn: $asn})-[:ORIGINATE]->(p:Prefix)<-[:PART_OF]-(:IP)<-[:RESOLVES_TO]-(h:HostName & !AuthoritativeNameServer)-[:PART_OF]->(d:DomainName)-[rr:RANK]->(rn:Ranking)
+  query: `MATCH (:AS {asn: $asn})-[:ORIGINATE]->(p:BGPPrefix)<-[:PART_OF]-(:IP)<-[:RESOLVES_TO]-(h:HostName & !AuthoritativeNameServer)-[:PART_OF]->(d:DomainName)-[rr:RANK]->(rn:Ranking)
     WHERE rr.rank < 100000 and rr.reference_name = 'tranco.top1m'
     RETURN DISTINCT h.name AS hostName, rr.rank AS rank, rn.name AS rankingName, split(h.name, '.')[-1] AS tld, 1/toFloat(rr.rank) AS inv_rank, COLLECT(DISTINCT p.prefix) AS prefix
     ORDER BY rank`,

--- a/src/components/iyp/as/ASRPKIRouteOriginAuthorization.vue
+++ b/src/components/iyp/as/ASRPKIRouteOriginAuthorization.vue
@@ -13,7 +13,7 @@ const roas = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (a:AS {asn: $asn})-[roa:ROUTE_ORIGIN_AUTHORIZATION]-(p:Prefix)
+  query: `MATCH (a:AS {asn: $asn})-[roa:ROUTE_ORIGIN_AUTHORIZATION]-(p:RPKIPrefix)
     OPTIONAL MATCH (b:AS)-[:ORIGINATE]->(p)
     RETURN p.prefix AS prefix, roa.maxLength AS maxLength, roa.notBefore AS notBefore, roa.notAfter AS notAfter, roa.uri AS uri, COLLECT(DISTINCT b.asn) AS bgp`,
   columns: [

--- a/src/components/iyp/country/CountryIPPrefixes.vue
+++ b/src/components/iyp/country/CountryIPPrefixes.vue
@@ -19,13 +19,13 @@ const prefixes = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (:Country {country_code: $cc})-[:COUNTRY]-(p:Prefix)
+  query: `MATCH (:Country {country_code: $cc})-[:COUNTRY]-(p:BGPPrefix)
     OPTIONAL MATCH (p)<-[o:ORIGINATE {reference_org:'IHR'}]-(a:AS)
     OPTIONAL MATCH (p)-[:COUNTRY {reference_org:'IHR'}]->(c:Country)
     OPTIONAL MATCH (p)-[creg:COUNTRY {reference_org:'NRO'}]->(creg_country:Country)
     OPTIONAL MATCH (p)-[:CATEGORIZED]->(t:Tag)
-    OPTIONAL MATCH (p)-[:PART_OF]->(cover:Prefix)-[cover_creg:ASSIGNED {reference_org:'NRO'}]->(:OpaqueID)
-    OPTIONAL MATCH (cover:Prefix)-[cover_creg:ASSIGNED {reference_org:'NRO'}]->(cover_creg_country:Country)
+    OPTIONAL MATCH (p)-[:PART_OF]->(cover:BGPPrefix)-[cover_creg:ASSIGNED {reference_org:'NRO'}]->(:OpaqueID)
+    OPTIONAL MATCH (cover:BGPPrefix)-[cover_creg:ASSIGNED {reference_org:'NRO'}]->(cover_creg_country:Country)
     RETURN c.country_code AS cc, toUpper(COALESCE(creg.registry, cover_creg.registry, '-')) AS rir, toUpper(COALESCE(creg_country.country_code, cover_creg_country.country_code, '-')) AS rir_country, p.prefix AS prefix, COLLECT(DISTINCT(t.label)) AS tags, COLLECT(DISTINCT o.descr) AS descr, COLLECT(DISTINCT o.visibility) AS visibility, COLLECT(DISTINCT a.asn) AS asn `,
   columns: [
     {

--- a/src/components/iyp/country/CountryInternetExchangePointsDomesticDistribution.vue
+++ b/src/components/iyp/country/CountryInternetExchangePointsDomesticDistribution.vue
@@ -21,7 +21,7 @@ const ixps = ref({
   loading: true,
   query: `
     MATCH (member:AS)-[:COUNTRY {reference_org:'NRO'}]-(:Country {country_code:$country_code})
-    WHERE (member)-[:ORIGINATE]-(:Prefix)
+    WHERE (member)-[:ORIGINATE]-(:BGPPrefix)
     OPTIONAL MATCH (ix:IXP)-[:MEMBER_OF]-(member)
     WITH ix, COLLECT(member) AS members, COUNT(DISTINCT member) AS ixp_domestic_members
     UNWIND members as member
@@ -32,7 +32,7 @@ const ixps = ref({
     ORDER BY ixp_domestic_members`,
   metadata: `
     MATCH (member:AS)-[:COUNTRY {reference_org:'NRO'}]-(:Country {country_code:$country_code})
-    WHERE (member)-[:ORIGINATE]-(:Prefix)
+    WHERE (member)-[:ORIGINATE]-(:BGPPrefix)
     OPTIONAL MATCH (member)-[:CATEGORIZED {reference_name:'bgptools.as_names'}]-(tag:Tag)
     OPTIONAL MATCH (member)-[mem:MEMBER_OF]-(ix:IXP)-[:COUNTRY]-(ix_country:Country)
     OPTIONAL MATCH (ix)-[man:MANAGED_BY]-(org:Organization)

--- a/src/components/iyp/country/CountryInternetExchangePointsInternationalDistribution.vue
+++ b/src/components/iyp/country/CountryInternetExchangePointsInternationalDistribution.vue
@@ -20,21 +20,21 @@ const ixps = ref({
   loading: true,
   query: `
     MATCH (ix:IXP)-[:MEMBER_OF]-(member:AS)-[:COUNTRY {reference_org:'NRO'}]-(:Country {country_code:$country_code})
-    WHERE (member)-[:ORIGINATE]-(:Prefix)
+    WHERE (member)-[:ORIGINATE]-(:BGPPrefix)
     WITH ix, COUNT(DISTINCT member) AS ixp_domestic_members
     MATCH (member:AS)-[mem:MEMBER_OF]-(ix:IXP)-[ix_country_rel:COUNTRY]-(ix_country:Country {country_code:$country_code})
     MATCH (member:AS)-[:COUNTRY {reference_org:'NRO'}]-(as_country:Country)
-    WHERE  as_country.country_code <> $country_code AND (member)-[:ORIGINATE]-(:Prefix) AND mem.reference_org = ix_country_rel.reference_org
+    WHERE  as_country.country_code <> $country_code AND (member)-[:ORIGINATE]-(:BGPPrefix) AND mem.reference_org = ix_country_rel.reference_org
     OPTIONAL MATCH (member)-[:CATEGORIZED {reference_name:'bgptools.as_names'}]-(tag:Tag)
     OPTIONAL MATCH (ix:IXP)-[:MANAGED_BY {reference_org:'PeeringDB'}]-(org:Organization)
     RETURN  member.asn AS asn, coalesce(tag.label, 'Other') AS label, ix.name AS ix_name, ix_country.country_code AS ix_country, as_country.country_code AS as_country, mem.reference_org AS mem_reference_org, org.name AS org_name, ixp_domestic_members
     ORDER BY ixp_domestic_members`,
   metadata: `
     MATCH (ix:IXP)-[:MEMBER_OF]-(member:AS)-[:COUNTRY {reference_org:'NRO'}]-(:Country {country_code:$country_code})
-    WHERE (member)-[:ORIGINATE]-(:Prefix)
+    WHERE (member)-[:ORIGINATE]-(:BGPPrefix)
     MATCH (member:AS)-[mem:MEMBER_OF]-(ix:IXP)-[:COUNTRY]-(ix_country:Country {country_code:$country_code})
     MATCH (member:AS)-[:COUNTRY {reference_org:'NRO'}]-(as_country:Country)
-    WHERE  as_country.country_code <> $country_code AND (member)-[:ORIGINATE]-(:Prefix)
+    WHERE  as_country.country_code <> $country_code AND (member)-[:ORIGINATE]-(:BGPPrefix)
     OPTIONAL MATCH (member)-[:CATEGORIZED {reference_name:'bgptools.as_names'}]-(tag:Tag)
     OPTIONAL MATCH (ix:IXP)-[:MANAGED_BY {reference_org:'PeeringDB'}]-(org:Organization)
     RETURN  member.asn AS asn`,

--- a/src/components/iyp/hostName/HostNameAuthoritativeNameservers.vue
+++ b/src/components/iyp/hostName/HostNameAuthoritativeNameservers.vue
@@ -18,7 +18,7 @@ const nameservers = ref({
   show: false,
   loading: true,
   query: `MATCH (:HostName {name: $hostname})-[:PART_OF]-(:DomainName)-[:MANAGED_BY]-(n:AuthoritativeNameServer)
-    OPTIONAL MATCH (n)-[:RESOLVES_TO]->(i:IP)-[:PART_OF]-(p:Prefix)-[:ORIGINATE]-(a:AS)
+    OPTIONAL MATCH (n)-[:RESOLVES_TO]->(i:IP)-[:PART_OF]-(p:BGPPrefix)-[:ORIGINATE]-(a:AS)
     OPTIONAL MATCH (p)-[:CATEGORIZED]->(t:Tag)
     RETURN  DISTINCT i.ip AS ip, n.name as nameserver, a.asn AS asn, p.prefix AS prefix, COLLECT(DISTINCT t.label) AS tags`,
   columns: [

--- a/src/components/iyp/hostName/HostNameIPAddressesPrefixes.vue
+++ b/src/components/iyp/hostName/HostNameIPAddressesPrefixes.vue
@@ -18,7 +18,7 @@ const ips = ref({
   show: false,
   loading: true,
   query: `MATCH (:HostName {name: $hostname})-[:RESOLVES_TO]-(i:IP)
-    OPTIONAL MATCH (i)-[:PART_OF]-(p:Prefix)-[:ORIGINATE]-(a:AS)
+    OPTIONAL MATCH (i)-[:PART_OF]-(p:BGPPrefix)-[:ORIGINATE]-(a:AS)
     OPTIONAL MATCH (a)-[:NAME {reference_org:'PeeringDB'}]->(pdbn:Name)
     OPTIONAL MATCH (a)-[:NAME {reference_org:'BGP.Tools'}]->(btn:Name)
     OPTIONAL MATCH (a)-[:NAME {reference_org:'RIPE NCC'}]->(ripen:Name)

--- a/src/components/iyp/ixp/IXPPeeringLANs.vue
+++ b/src/components/iyp/ixp/IXPPeeringLANs.vue
@@ -15,7 +15,7 @@ const peeringLANs = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (:PeeringdbIXID {id: $id})<-[:EXTERNAL_ID]-(:IXP)<-[:MANAGED_BY {reference_org: 'PeeringDB'}]-(s:Prefix)
+  query: `MATCH (:PeeringdbIXID {id: $id})<-[:EXTERNAL_ID]-(:IXP)<-[:MANAGED_BY {reference_org: 'PeeringDB'}]-(s:PeeringLAN)
     OPTIONAL MATCH (s)-[:ORIGINATE]-(a:AS)
     RETURN s.prefix as prefix, s.af as af, COLLECT(DISTINCT a.asn) as orig`,
   columns: [

--- a/src/components/iyp/ixp/IXPRPKIRouteOriginAuthorization.vue
+++ b/src/components/iyp/ixp/IXPRPKIRouteOriginAuthorization.vue
@@ -14,7 +14,7 @@ const roas = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (:PeeringdbIXID {id: $id})<-[:EXTERNAL_ID]-(:IXP)<-[m:MANAGED_BY]-(p:Prefix)
+  query: `MATCH (:PeeringdbIXID {id: $id})<-[:EXTERNAL_ID]-(:IXP)<-[m:MANAGED_BY]-(p:PeeringLAN)
     WHERE m.reference_org <> 'CAIDA'
     OPTIONAL MATCH (p)-[roa:ROUTE_ORIGIN_AUTHORIZATION]-(a:AS)
     OPTIONAL MATCH (b:AS)-[:ORIGINATE]->(p)

--- a/src/components/iyp/prefix/PrefixAuthoritativeNameservers.vue
+++ b/src/components/iyp/prefix/PrefixAuthoritativeNameservers.vue
@@ -16,7 +16,7 @@ const nameservers = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (p:Prefix {prefix: $prefix})<-[:PART_OF]-(i:IP)<-[:RESOLVES_TO]-(n:AuthoritativeNameServer)
+  query: `MATCH (p:BGPPrefix {prefix: $prefix})<-[:PART_OF]-(i:IP)<-[:RESOLVES_TO]-(n:AuthoritativeNameServer)
     OPTIONAL MATCH (n)<-[:MANAGED_BY]-(:DomainName)-[:PART_OF]-(d:HostName)
     RETURN COLLECT(DISTINCT i.ip) AS ip, n.name as nameserver, split(n.name, '.')[-1] AS tld, COUNT(DISTINCT d.name) AS nb_hostnames`,
   columns: [

--- a/src/components/iyp/prefix/PrefixRPKIRouteOriginAuthorization.vue
+++ b/src/components/iyp/prefix/PrefixRPKIRouteOriginAuthorization.vue
@@ -14,7 +14,7 @@ const roas = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (p:Prefix {prefix: $prefix})-[roa:ROUTE_ORIGIN_AUTHORIZATION]-(a:AS)
+  query: `MATCH (p:RPKIPrefix {prefix: $prefix})-[roa:ROUTE_ORIGIN_AUTHORIZATION]-(a:AS)
     RETURN a.asn AS asn, roa.maxLength AS maxLength, roa.notBefore AS notBefore, roa.notAfter AS notAfter, roa.uri AS uri`,
   columns: [
     {

--- a/src/components/iyp/prefix/PrefixUpstreamASes.vue
+++ b/src/components/iyp/prefix/PrefixUpstreamASes.vue
@@ -14,7 +14,7 @@ const upstreams = ref({
   data: [],
   show: false,
   loading: true,
-  query: `MATCH (p:Prefix {prefix: $prefix})-[dep:DEPENDS_ON]-(a:AS)-[:NAME]-(n:Name)
+  query: `MATCH (p:BGPPrefix {prefix: $prefix})-[dep:DEPENDS_ON]-(a:AS)-[:NAME]-(n:Name)
     OPTIONAL MATCH (a)-[:COUNTRY {reference_org:'NRO'}]-(c:Country)
     RETURN DISTINCT a.asn AS asn, head(collect(c.country_code)) AS cc, head(collect(DISTINCT(n.name))) AS name, 100*dep.hege AS hege `,
   columns: [

--- a/src/components/networks/as/ASOverview.vue
+++ b/src/components/networks/as/ASOverview.vue
@@ -42,9 +42,9 @@ const queries = ref([
   {
     data: [],
     query: `MATCH (a:AS {asn: $asn})
-      OPTIONAL MATCH (a)-[:ORIGINATE]->(p4:Prefix {af:4})
+      OPTIONAL MATCH (a)-[:ORIGINATE]->(p4:BGPPrefix {af:4})
       WITH COALESCE(COUNT(DISTINCT p4.prefix), 0) AS prefixes_v4, a
-      OPTIONAL MATCH (a)-[:ORIGINATE]->(p6:Prefix {af:6})
+      OPTIONAL MATCH (a)-[:ORIGINATE]->(p6:BGPPrefix {af:6})
       WITH COALESCE(COUNT(DISTINCT p6.prefix), 0) AS prefixes_v6, prefixes_v4, a
       OPTIONAL MATCH (a)-[:NAME {reference_org:'PeeringDB'}]->(pdbn:Name)
       OPTIONAL MATCH (a)-[:NAME {reference_org:'BGP.Tools'}]->(btn:Name)
@@ -68,7 +68,7 @@ const queries = ref([
   },
   {
     data: [],
-    query: `MATCH (:AS {asn: $asn})-[:ORIGINATE]->(:Prefix)<-[:PART_OF]-(:IP)<-[:RESOLVES_TO]-(h:HostName)-[:PART_OF]-(d:DomainName)-[rr:RANK]->(rn:Ranking)
+    query: `MATCH (:AS {asn: $asn})-[:ORIGINATE]->(:BGPPrefix)<-[:PART_OF]-(:IP)<-[:RESOLVES_TO]-(h:HostName)-[:PART_OF]-(d:DomainName)-[rr:RANK]->(rn:Ranking)
       WHERE rr.reference_name = "tranco.top1m" AND h.name = d.name
       RETURN DISTINCT h.name AS hostname, rr.rank AS rank
       ORDER BY rank LIMIT 5`

--- a/src/components/networks/country/CountryOverview.vue
+++ b/src/components/networks/country/CountryOverview.vue
@@ -30,8 +30,8 @@ const queries = ref([
     query: `MATCH (c:Country {country_code: $cc})
       OPTIONAL MATCH (c)<-[:COUNTRY {reference_name: "nro.delegated_stats"}]-(a:AS) WITH c, COUNT(DISTINCT a) as as_count
       OPTIONAL MATCH (c)<-[:COUNTRY {reference_name: "peeringdb.ix"}]-(i:IXP) WITH c, as_count, COUNT(DISTINCT i) as ixp_count
-      OPTIONAL MATCH (c)<-[:COUNTRY {reference_name: "nro.delegated_stats"}]-(pd:Prefix) WITH c, as_count, ixp_count, COUNT(DISTINCT pd) as preg_count
-      OPTIONAL MATCH (c)<-[:COUNTRY {reference_name: "ihr.rov"}]-(pg:Prefix) WITH c, as_count, ixp_count, preg_count, COUNT(DISTINCT pg) as pgeo_count
+      OPTIONAL MATCH (c)<-[:COUNTRY {reference_name: "nro.delegated_stats"}]-(pd:RIRPrefix) WITH c, as_count, ixp_count, COUNT(DISTINCT pd) as preg_count
+      OPTIONAL MATCH (c)<-[:COUNTRY {reference_name: "ihr.rov"}]-(pg:BGPPrefix) WITH c, as_count, ixp_count, preg_count, COUNT(DISTINCT pg) as pgeo_count
       RETURN c.name AS country_name, as_count, ixp_count, preg_count, pgeo_count`
   },
   {
@@ -47,7 +47,7 @@ const queries = ref([
   {
     data: [],
     query: `MATCH (c:Country {country_code: $cc})-[:COUNTRY {reference_name:'nro.delegated_stats'}]-(a:AS)-[ca:CATEGORIZED]-(:Tag {label:'Tranco 10k Host'}),
-      (a)-[:ORIGINATE]-(:Prefix)-[:PART_OF]-(:IP)-[re:RESOLVES_TO {reference_name:'openintel.tranco1m'}]-(d:HostName)
+      (a)-[:ORIGINATE]-(:BGPPrefix)-[:PART_OF]-(:IP)-[re:RESOLVES_TO {reference_name:'openintel.tranco1m'}]-(d:HostName)
       USING INDEX re:RESOLVES_TO(reference_name)
       WITH a, COUNT(DISTINCT d) AS nb_domains ORDER BY nb_domains DESC LIMIT 5
       OPTIONAL MATCH (a)-[:NAME {reference_org:'PeeringDB'}]->(pdbn:Name)

--- a/src/components/networks/ixp/IXPOverview.vue
+++ b/src/components/networks/ixp/IXPOverview.vue
@@ -25,7 +25,7 @@ const getOverview = () => {
       OPTIONAL MATCH (i)-[:MANAGED_BY]->(o:Organization)
       OPTIONAL MATCH (i)-[:COUNTRY]->(c:Country)
       OPTIONAL MATCH (i)-[:WEBSITE]->(u:URL)
-      OPTIONAL MATCH (i)<-[p:MANAGED_BY]-(plan:Prefix)
+      OPTIONAL MATCH (i)<-[p:MANAGED_BY]-(plan:PeeringLAN)
       WHERE p.reference_org <> 'CAIDA'
       OPTIONAL MATCH (i)<-[m:MEMBER_OF]-(a:AS)
       WHERE m.reference_org <> 'CAIDA'

--- a/src/plugins/IypApi.js
+++ b/src/plugins/IypApi.js
@@ -80,7 +80,8 @@ import cache from './cache.js'
 import { get } from 'idb-keyval'
 
 /// Base url for api
-const IYP_API_BASE = 'https://iyp.iijlab.net/iyp/db/neo4j/tx/'
+//const IYP_API_BASE = 'https://iyp.iijlab.net/iyp/db/neo4j/tx/'
+const IYP_API_BASE = 'http://iyp-bolt.ihr.live:7474/db/neo4j/tx/'
 /// Default timeout before api call are considered failed
 const DEFAULT_TIMEOUT = 180000
 


### PR DESCRIPTION
This update IYP queries that are using the Prefix nodes. The new version of IYP has more specific types (BGPPrefix, GeoPrefix, etc..). 

This code works only on the newer IYP version. So I changed the endpoint for the IYP API. But this is temporary. After deploying the new website we should update the IYP database at iyp.iijlab.net.

It also makes the RIR information in network->routing->originated prefixes irrelevant.

## How Has This Been Tested?

Tested with the IYP instance: iyp-bolt.ihr.live

The IYP_API_BASE variable is set to go to the test instance:
```
const IYP_API_BASE = 'http://iyp-bolt.ihr.live:7474/db/neo4j/tx/'
```

I think we could deploy the new website like that then update the IYP database at iyp.iijlab.net, and set back the IYP_API_BASE variable to iyp.iijlab.net

## Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
