### PR TITLE
Fixed determining RIS Live BGP message types (Announcement/Withdrawal)

### DIFF
--- a/src/components/charts/BGPLineChart.vue
+++ b/src/components/charts/BGPLineChart.vue
@@ -69,7 +69,7 @@ const generateLineChartData = async (message) => {
   let dates = []
   let announcementsTrace = []
   let withdrawalsTrace = []
-  if (props.dataSource === 'risLive') {
+  if (props.dataSource === 'ris-live') {
     const timestamp = message.timestamp
     //count no of messages based on type
     if (message.type === 'Announce') {
@@ -108,7 +108,7 @@ const timestampToUTC = (timestamp) => {
 
 // Update the time range
 const updateTimeRange = (timestamp) => {
-  if (props.dataSource === 'risLive') {
+  if (props.dataSource === 'ris-live') {
     if (timestamp) {
       if (timestamp < minTimestamp.value) {
         minTimestamp.value = timestamp
@@ -279,11 +279,11 @@ onMounted(() => {
   <div class="noData" v-if="rawMessages.length === 0">
     <h1 v-if="isLoadingBgplayData">Loading...</h1>
     <h1 v-else>No data available</h1>
-    <h3 v-if="dataSource === 'risLive'">Try Changing the Input Parameters or you can wait</h3>
-    <h6 v-if="dataSource === 'risLive'">Note: Some prefixes become active after some time.</h6>
+    <h3 v-if="dataSource === 'ris-live'">Try Changing the Input Parameters or you can wait</h3>
+    <h6 v-if="dataSource === 'ris-live'">Note: Some prefixes become active after some time.</h6>
   </div>
   <div v-else>
-    <div v-if="dataSource === 'risLive'">
+    <div v-if="dataSource === 'ris-live'">
       <QBtn v-if="isLiveMode && isPlaying" color="negative" label="Live" />
       <QBtn v-else color="grey-9" label="Go to Live" @click="enableLiveMode" />
     </div>
@@ -296,7 +296,7 @@ onMounted(() => {
     />
     <div class="timetampSlider">
       <div class="timeStampControls">
-        <span v-if="dataSource === 'risLive'"
+        <span v-if="dataSource === 'ris-live'"
           >Using: {{ usedMessagesCount + '/' + rawMessages.length }} Messages</span
         >
         <span v-else

--- a/src/components/charts/BGPLineChart.vue
+++ b/src/components/charts/BGPLineChart.vue
@@ -132,20 +132,26 @@ const renderChart = (dates, announcementsTrace, withdrawalsTrace) => {
     {
       x: dates,
       y: withdrawalsTrace,
-      type: 'scatter',
-      mode: 'none',
-      name: 'Withdrawals',
+      type: 'scattergl',
+      mode: 'markers',
+      fill: 'tozeroy',
       fillcolor: 'rgba(255, 127, 14, 0.5)',
-      stackgroup: 'one'
+      marker: {
+        color: 'rgba(255, 127, 14, 0.5)'
+      },
+      name: 'Withdrawals'
     },
     {
       x: dates,
       y: announcementsTrace,
-      type: 'scatter',
-      mode: 'none',
-      name: 'Announcements',
+      type: 'scattergl',
+      fill: 'tozeroy',
       fillcolor: 'rgba(31, 119, 180, 0.5)',
-      stackgroup: 'one'
+      marker: {
+        color: 'rgba(31, 119, 180, 0.5)'
+      },
+      mode: 'markers',
+      name: 'Announcements'
     }
   ]
 

--- a/src/components/charts/BGPPathsChart.vue
+++ b/src/components/charts/BGPPathsChart.vue
@@ -185,14 +185,14 @@ onMounted(() => {
   <div v-else-if="props.isNoData">
     <div class="text-center">
       <h1>No data available</h1>
-      <template v-if="dataSource === 'risLive'">
+      <template v-if="dataSource === 'ris-live'">
         <h3>Try Changing the Input Parameters or you can wait</h3>
         <h6>Note: Some prefixes become active after some time.</h6>
       </template>
     </div>
   </div>
   <div v-else>
-    <div v-if="dataSource === 'risLive'">
+    <div v-if="dataSource === 'ris-live'">
       <QBtn v-if="isLiveMode && isPlaying" color="negative" label="Live" />
       <QBtn v-else color="grey-9" label="Go to Live" @click="enableLiveMode" />
     </div>

--- a/src/components/tables/BGPMessagesTable.vue
+++ b/src/components/tables/BGPMessagesTable.vue
@@ -127,15 +127,14 @@ watch(selectedPeersModel, () => {
     </template>
     <template #body-cell-as_info="props">
       <QTd :props="props">
-        <pre
-          >{{
-            props.row.as_info.length > 0
-              ? props.row.as_info
-                  .map((info) => `${info.asn}: ${info.asn_name}, ${info.country_iso_code2}`)
-                  .join('\n')
-              : 'Null'
-          }}
-        </pre>
+        <template v-if="props.row.as_info.length > 0">
+          <pre>{{
+            props.row.as_info
+              .map((info) => `${info.asn}: ${info.asn_name}, ${info.country_iso_code2}`)
+              .join('\n')
+          }}</pre>
+        </template>
+        <template v-else>Null</template>
       </QTd>
     </template>
     <template #body-cell-timestamp="props">
@@ -143,15 +142,14 @@ watch(selectedPeersModel, () => {
     </template>
     <template #body-cell-community="props">
       <QTd :props="props">
-        <pre
-          >{{
-            props.row.community.length > 0
-              ? props.row.community
-                  .map((c) => `${c.community}, AS${c.comm_1}-${c.description}`)
-                  .join('\n')
-              : 'Null'
-          }}
-        </pre>
+        <template v-if="props.row.community.length > 0">
+          <pre>{{
+            props.row.community
+              .map((c) => `${c.community}, AS${c.comm_1}-${c.description}`)
+              .join('\n')
+          }}</pre>
+        </template>
+        <template v-else> Null </template>
       </QTd>
     </template>
   </QTable>

--- a/src/components/tables/BGPMessagesTable.vue
+++ b/src/components/tables/BGPMessagesTable.vue
@@ -87,7 +87,7 @@ watch(selectedPeersModel, () => {
     row-key="peer"
     selection="multiple"
   >
-    <template #top-left v-if="props.filteredMessages.length !== 0 && dataSource === 'risLive'">
+    <template #top-left v-if="props.filteredMessages.length !== 0 && dataSource === 'ris-live'">
       <QBtn v-if="isLiveMode && isPlaying" color="negative" label="Live" />
       <QBtn v-else color="grey-9" label="Go to Live" @click="enableLiveMode" />
     </template>

--- a/src/views/BGPMonitor.vue
+++ b/src/views/BGPMonitor.vue
@@ -851,7 +851,7 @@ onMounted(() => {
               !haveRequiredBGPlayParams()
             "
           />
-          <QBtn color="negative" :label="'Reset'" :disable="isPlaying" @click="resetData" />
+          <QBtn color="negative" :label="'Reset'" @click="resetData" />
           <div class="column">
             <span>Displaying Unique Peer messages: {{ filteredMessages.length }}</span>
             <span>Total messages received: {{ rawMessages.length }}</span>

--- a/src/views/BGPMonitor.vue
+++ b/src/views/BGPMonitor.vue
@@ -50,7 +50,7 @@ const inputDisable = ref(false)
 const isWsDisconnected = ref(false)
 const normalizedPrefix = ref('') // Used to store the normalized prefix to determine the BGP message type
 
-const dataSource = ref('risLive') //'risLive' or 'bgplay'
+const dataSource = ref('ris-live') //'ris-live' or 'bgplay'
 const minTimestamp = ref(Infinity)
 const maxTimestamp = ref(-Infinity)
 
@@ -125,30 +125,30 @@ const initRoute = () => {
   } else {
     query.prefix = params.value.prefix
   }
-  if (route.query.maxHops) {
-    maxHops.value = parseInt(route.query.maxHops)
+  if (route.query['max-hops']) {
+    maxHops.value = parseInt(route.query['max-hops'])
   } else {
-    query.maxHops = maxHops.value
+    query['max-hops'] = maxHops.value
   }
   if (route.query.rrc) {
     params.value.host = route.query.rrc
   } else {
     query.rrc = params.value.host
   }
-  if (route.query.dataSource) {
-    dataSource.value = route.query.dataSource
+  if (route.query['data-source']) {
+    dataSource.value = route.query['data-source']
   } else {
-    query.dataSource = dataSource.value
+    query['data-source'] = dataSource.value
   }
-  if (route.query.startTime) {
-    startTime.value = route.query.startTime
+  if (route.query['start-time']) {
+    startTime.value = route.query['start-time']
   } else {
-    query.startTime = startTime.value
+    query['start-time'] = startTime.value
   }
-  if (route.query.endTime) {
-    endTime.value = route.query.endTime
+  if (route.query['end-time']) {
+    endTime.value = route.query['end-time']
   } else {
-    query.endTime = endTime.value
+    query['end-time'] = endTime.value
   }
   if (route.query.rrcs) {
     rrcs.value = route.query.rrcs.split(',').map(Number)
@@ -230,7 +230,7 @@ const sendSocketType = (protocol, paramData) => {
 }
 
 const processResData = (data) => {
-  if (dataSource.value === 'risLive') {
+  if (dataSource.value === 'ris-live') {
     data.community = addCommunityAndDescriptions(data.community)
     data.as_info = addASInfo(data.path)
     data.type = addBGPMessageType(data)
@@ -374,7 +374,7 @@ const addCommunityAndDescriptions = (communityDataArray) => {
 const addASInfo = (asPathArray) => {
   if (!Array.isArray(asPathArray) || asPathArray.length === 0) return []
 
-  const source = dataSource.value === 'risLive' ? asNames.value : bgPlayASNames.value
+  const source = dataSource.value === 'ris-live' ? asNames.value : bgPlayASNames.value
   const seen = new Set()
 
   const result = []
@@ -407,7 +407,7 @@ const normalizePrefix = (prefix) => {
 
 // Determine the BGP message type
 const addBGPMessageType = (data) => {
-  if (dataSource.value === 'risLive') {
+  if (dataSource.value === 'ris-live') {
     const withdrawalSet = new Set(data.withdrawals.map(normalizePrefix))
     const announcementSet = new Set((data.announcements[0]?.prefixes || []).map(normalizePrefix))
 
@@ -667,11 +667,11 @@ watch(
     const query = {
       ...route.query,
       prefix: params.value.prefix,
-      maxHops: maxHops.value,
+      'max-hops': maxHops.value,
       rrc: params.value.host,
-      dataSource: dataSource.value,
-      startTime: startTime.value,
-      endTime: endTime.value,
+      'data-source': dataSource.value,
+      'start-time': startTime.value,
+      'end-time': endTime.value,
       rrcs: rrcs.value ? rrcs.value.join(',') : ''
     }
     router.replace({ query })
@@ -702,7 +702,7 @@ onMounted(() => {
         <div>
           <QRadio
             v-model="dataSource"
-            val="risLive"
+            val="ris-live"
             label="RisLive"
             :disable="
               isPlaying ||
@@ -750,7 +750,7 @@ onMounted(() => {
               "
             />
             <QSelect
-              v-if="dataSource === 'risLive'"
+              v-if="dataSource === 'ris-live'"
               v-model="params.host"
               filled
               :options="rrcList"
@@ -827,7 +827,7 @@ onMounted(() => {
         </div>
         <div class="row items-center justify-center gap-30">
           <QBtn
-            v-if="dataSource === 'risLive'"
+            v-if="dataSource === 'ris-live'"
             :color="disableButton ? 'grey-9' : isPlaying ? 'secondary' : 'positive'"
             :label="disableButton ? 'Connecting' : isPlaying ? 'Pause' : 'Play'"
             :disable="disableButton || params.prefix === ''"

--- a/src/views/BGPMonitor.vue
+++ b/src/views/BGPMonitor.vue
@@ -103,7 +103,6 @@ const resetData = () => {
   selectedMaxTimestamp.value = 0
   usedMessagesCount.value = 0
   inputDisable.value = false
-  normalizedPrefix.value = ''
 
   bgPlaySources.value = {}
   bgPlayInitialState.value = []
@@ -393,12 +392,17 @@ const addASInfo = (asPathArray) => {
 }
 
 const normalizePrefix = (prefix) => {
-  if (Address4.isValid(prefix)) {
-    return new Address4(prefix).correctForm()
-  } else if (Address6.isValid(prefix)) {
-    return new Address6(prefix).correctForm()
+  const [ip, length] = prefix.split('/')
+  let normalizedIp
+  if (Address4.isValid(ip)) {
+    normalizedIp = new Address4(ip).correctForm()
+  } else if (Address6.isValid(ip)) {
+    normalizedIp = new Address6(ip).correctForm()
+  } else {
+    console.warn(`Invalid prefix: ${prefix}`)
+    normalizedIp = ip // use the original IP if invalid
   }
-  return prefix
+  return length ? `${normalizedIp}/${length}` : normalizedIp
 }
 
 // Determine the BGP message type
@@ -412,6 +416,7 @@ const addBGPMessageType = (data) => {
     } else if (announcementSet.has(normalizedPrefix.value)) {
       return 'Announce'
     } else {
+      console.warn(`Unknown BGP message type:`, data)
       return 'Unknown'
     }
   } else {

--- a/src/views/BGPMonitor.vue
+++ b/src/views/BGPMonitor.vue
@@ -119,6 +119,7 @@ const resetData = () => {
 // Initialize the route
 const initRoute = () => {
   const query = { ...route.query }
+
   if (route.query.prefix) {
     params.value.prefix = route.query.prefix
     normalizedPrefix.value = normalizePrefix(route.query.prefix)
@@ -130,30 +131,34 @@ const initRoute = () => {
   } else {
     query['max-hops'] = maxHops.value
   }
-  if (route.query.rrc) {
-    params.value.host = route.query.rrc
-  } else {
-    query.rrc = params.value.host
-  }
   if (route.query['data-source']) {
     dataSource.value = route.query['data-source']
   } else {
     query['data-source'] = dataSource.value
   }
-  if (route.query['start-time']) {
-    startTime.value = route.query['start-time']
+
+  if (dataSource.value === 'ris-live') {
+    if (route.query.rrc) {
+      params.value.host = route.query.rrc
+    } else {
+      query.rrc = params.value.host
+    }
   } else {
-    query['start-time'] = startTime.value
-  }
-  if (route.query['end-time']) {
-    endTime.value = route.query['end-time']
-  } else {
-    query['end-time'] = endTime.value
-  }
-  if (route.query.rrcs) {
-    rrcs.value = route.query.rrcs.split(',').map(Number)
-  } else {
-    query.rrcs = rrcs.value.join(',')
+    if (route.query.rrcs) {
+      rrcs.value = route.query.rrcs.split(',').map(Number)
+    } else {
+      query.rrcs = rrcs.value.join(',')
+    }
+    if (route.query['start-time']) {
+      startTime.value = route.query['start-time']
+    } else {
+      query['start-time'] = startTime.value
+    }
+    if (route.query['end-time']) {
+      endTime.value = route.query['end-time']
+    } else {
+      query['end-time'] = endTime.value
+    }
   }
   router.replace({ query })
 }
@@ -665,14 +670,16 @@ watch(
   [params, maxHops, dataSource, startTime, endTime, rrcs],
   () => {
     const query = {
-      ...route.query,
       prefix: params.value.prefix,
       'max-hops': maxHops.value,
-      rrc: params.value.host,
-      'data-source': dataSource.value,
-      'start-time': startTime.value,
-      'end-time': endTime.value,
-      rrcs: rrcs.value ? rrcs.value.join(',') : ''
+      'data-source': dataSource.value
+    }
+    if (dataSource.value === 'ris-live') {
+      query.rrc = params.value.host
+    } else {
+      query['start-time'] = startTime.value
+      query['end-time'] = endTime.value
+      query.rrcs = rrcs.value ? rrcs.value.join(',') : ''
     }
     router.replace({ query })
     normalizedPrefix.value = normalizePrefix(params.value.prefix)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Do not include backticks (`) in the Title above.  -->

## Description

This PR fixes the determination of RIS Live message types (Announcements and Withdrawals). It uses the `ip-address` library to convert both the user monitored prefix and the prefixes in the message's Announcements and Withdrawals arrays into their RFC 5952 canonical form. For example:

Input: `2001:0db8:0000:0000:0000:0000:0000:0001`
Output: `2001:db8::1`

## Related issue

<!--- Replace only the '000' with the issue number. -->
<!--- Do not include a URL. -->

#994

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to. -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Do not include backticks (`).  -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
