### PR TITLE
Minor Improvements for the BGP Monitor

### DIFF
--- a/src/components/charts/BGPLineChart.vue
+++ b/src/components/charts/BGPLineChart.vue
@@ -112,7 +112,8 @@ const defaultLayout = {
   },
   shapes: [],
   showlegend: true,
-  yaxis: { rangemode: 'tozero' }
+  xaxis: { autorange: true },
+  yaxis: { autorange: true, rangemode: 'tozero' }
 }
 
 const lineChartLayout = {
@@ -297,6 +298,16 @@ watch(
       lineChartLayout.shapes = []
       rpkiLayout.shapes = []
       updateTimeRange()
+    }
+  }
+)
+
+watch(
+  () => props.rawMessages,
+  () => {
+    if (props.rawMessages.length === 0) {
+      defaultLayout.xaxis.autorange = true
+      defaultLayout.yaxis.autorange = true
     }
   }
 )

--- a/src/views/BGPMonitor.vue
+++ b/src/views/BGPMonitor.vue
@@ -62,8 +62,11 @@ const dataSourceOptions = ['ris-live', 'bgplay']
 const minTimestamp = ref(Infinity)
 const maxTimestamp = ref(-Infinity)
 
+const tempStartTime = ref(new Date().toISOString().slice(0, 16))
+const tempEndTime = ref(new Date().toISOString().slice(0, 16))
 const startTime = ref(new Date().toISOString().slice(0, 16))
 const endTime = ref(new Date().toISOString().slice(0, 16))
+
 const rrcs = ref([])
 const rrcLocations = ref([])
 const isLoadingBgplayData = ref(false)
@@ -205,11 +208,13 @@ const initRoute = () => {
       query.rrcs = rrcs.value.join(',')
     }
     if (queryStartTime) {
+      tempStartTime.value = queryStartTime
       startTime.value = queryStartTime
     } else {
       query['start-time'] = startTime.value
     }
     if (queryEndTime) {
+      tempEndTime.value = queryEndTime
       endTime.value = queryEndTime
     } else {
       query['end-time'] = endTime.value
@@ -1099,6 +1104,19 @@ const updateSelectedPeers = (obj) => {
   selectedPeers.value = obj
 }
 
+const applyStartTime = () => {
+  startTime.value = tempStartTime.value
+}
+
+const applyEndTime = () => {
+  endTime.value = tempEndTime.value
+}
+
+const resetTempValues = () => {
+  tempStartTime.value = startTime.value
+  tempEndTime.value = endTime.value
+}
+
 const customIntersectionObserver = () => {
   observer = new IntersectionObserver(
     (entries) => {
@@ -1232,20 +1250,32 @@ onUnmounted(() => {
                   <div v-if="dataSource === 'bgplay'" class="row">
                     <QInput
                       label="Start Date Time in (UTC)"
-                      v-model="startTime"
+                      v-model="tempStartTime"
                       class="input q-mr-xl"
                       :disable="Object.keys(bgPlaySources).length > 0 || isLoadingBgplayData"
                       outlined
                     >
                       <template v-slot:append>
                         <QIcon name="event" class="cursor-pointer">
-                          <QPopupProxy no-route-dismiss cover>
+                          <QPopupProxy no-route-dismiss cover @hide="resetTempValues">
                             <div class="q-pa-md q-gutter-md row items-start">
-                              <QDate flat v-model="startTime" mask="YYYY-MM-DDTHH:mm" />
-                              <QTime flat v-model="startTime" mask="YYYY-MM-DDTHH:mm" format24h />
+                              <QDate flat v-model="tempStartTime" mask="YYYY-MM-DDTHH:mm" />
+                              <QTime
+                                flat
+                                v-model="tempStartTime"
+                                mask="YYYY-MM-DDTHH:mm"
+                                format24h
+                              />
                             </div>
                             <div class="row items-center justify-end q-ma-md">
-                              <QBtn v-close-popup class="primary" label="Apply" outline />
+                              <QBtn v-close-popup class="primary q-mr-sm" label="Close" outline />
+                              <QBtn
+                                v-close-popup
+                                @click="applyStartTime"
+                                class="primary"
+                                label="Apply"
+                                outline
+                              />
                             </div>
                           </QPopupProxy>
                         </QIcon>
@@ -1253,20 +1283,27 @@ onUnmounted(() => {
                     </QInput>
                     <QInput
                       label="End Date Time in (UTC)"
-                      v-model="endTime"
+                      v-model="tempEndTime"
                       class="input q-mr-xl"
                       :disable="Object.keys(bgPlaySources).length > 0 || isLoadingBgplayData"
                       outlined
                     >
                       <template v-slot:append>
                         <QIcon name="event" class="cursor-pointer">
-                          <QPopupProxy no-route-dismiss cover>
+                          <QPopupProxy no-route-dismiss cover @hide="resetTempValues">
                             <div class="q-pa-md q-gutter-md row items-start">
-                              <QDate flat v-model="endTime" mask="YYYY-MM-DDTHH:mm" />
-                              <QTime flat v-model="endTime" mask="YYYY-MM-DDTHH:mm" format24h />
+                              <QDate flat v-model="tempEndTime" mask="YYYY-MM-DDTHH:mm" />
+                              <QTime flat v-model="tempEndTime" mask="YYYY-MM-DDTHH:mm" format24h />
                             </div>
                             <div class="row items-center justify-end q-ma-md">
-                              <QBtn v-close-popup class="primary" label="Apply" outline />
+                              <QBtn v-close-popup class="primary q-mr-sm" label="Close" outline />
+                              <QBtn
+                                v-close-popup
+                                @click="applyEndTime"
+                                class="primary"
+                                label="Apply"
+                                outline
+                              />
                             </div>
                           </QPopupProxy>
                         </QIcon>

--- a/src/views/BGPMonitor.vue
+++ b/src/views/BGPMonitor.vue
@@ -69,7 +69,8 @@ const rrcLocations = ref([])
 const isLoadingBgplayData = ref(false)
 const bgPlaySources = ref({}) // Used to store the "sources" for BGPlay
 const bgPlayASNames = ref({}) // Used to store the AS names we get from the BGPlay nodes Array
-const bgPlayInitialState = ref([]) // Used to store the initial state for BGPlay
+const bgPlayAdditionalMessagesReceived = ref(false)
+const bgPlayAdditionalMessages = ref([]) // Used to store any additional messages from BGPlay (res.data.messages[]) e.g warnings, errors etc
 const initialStateDataCount = ref(0)
 const datesTrace = ref([])
 const announcementsTrace = ref([])
@@ -134,7 +135,8 @@ const resetData = () => {
   inputDisable.value = false
 
   bgPlaySources.value = {}
-  bgPlayInitialState.value = []
+  bgPlayAdditionalMessagesReceived.value = false
+  bgPlayAdditionalMessages.value = []
   bgPlayASNames.value = {}
   minTimestamp.value = Infinity
   maxTimestamp.value = -Infinity
@@ -308,6 +310,12 @@ const processResData = (data) => {
     })
     generateLineChartTrace()
   } else {
+    if (data.messages.length > 0) {
+      bgPlayAdditionalMessages.value = data.messages
+      bgPlayAdditionalMessagesReceived.value = true
+      return
+    }
+
     //Temp variables to reduce the vue reactivity
     const sources = {}
     const nodes = {}
@@ -1459,6 +1467,23 @@ onUnmounted(() => {
             due to network issues. If the connection remains idle for too long, the server will also
             close the WebSocket connection.
           </p>
+        </QCardSection>
+        <QCardActions align="right">
+          <QBtn v-close-popup flat label="Close" color="primary" />
+        </QCardActions>
+      </QCard>
+    </QDialog>
+    <QDialog v-model="bgPlayAdditionalMessagesReceived">
+      <QCard style="width: 1000px; height: auto">
+        <QCardSection>
+          <div class="text-h6">Important Information from BGPlay</div>
+        </QCardSection>
+        <QCardSection class="q-pt-none">
+          <div v-for="(msg, index) in bgPlayAdditionalMessages" :key="index">
+            <p v-for="(data, i) in msg" :key="i">
+              {{ data }}
+            </p>
+          </div>
         </QCardSection>
         <QCardActions align="right">
           <QBtn v-close-popup flat label="Close" color="primary" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Do not include backticks (`) in the Title above.  -->

This PR does the following:

- Added a dialog box which shows messages received from the BGPlay response `data.messages[]`. If there are messages then the complete response data is ignored. For example `"Data is only available until 2025-09-04 07:59:52! Query time has been changed."`
- Fixed a UX bug where the zoomed chart layout persisted after resetting
- Changed the behaviour of the date time picker, now it will apply the date time only after clicking the "Apply" button.

<!--- Why is this change required? What problem does it solve? -->
<!--- Do not include backticks (`).  -->

## Related issue

<!--- Replace only the '000' with the issue number. -->
<!--- Do not include a URL. -->

#1012

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to. -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Do not include backticks (`).  -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
