### PR TITLE
fix(props): Resolve prop definition conflicts

### DIFF
--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -12,20 +12,19 @@ const props = defineProps({
   },
   min: {
     type: Date,
-    required: true,
     default: () => {
       return new Date()
     }
   },
   max: {
     type: Date,
-    required: true,
     default: () => {
       return new Date()
     }
   },
   white: {
-    type: Boolean
+    type: Boolean,
+    default:false
   },
   hideTime: {
     type: Boolean,


### PR DESCRIPTION
**fix(props): Remove contradictory 'required' from min/max props**

## Description

This PR addresses an issue in the `DateTimePicker` component where the `min` and `max` props were incorrectly defined as both `required: true` and having a `default` value. This contradicts Vue's prop validation rules.

The fix removes the `required: true` flag from the `min` and `max` props, allowing their default values (`new Date()`) to function correctly as intended.

Additionally, an explicit `default: false` has been added to the `white` prop for clarity, addressing another point raised during review.

## Related issue

#1023 

## How Has This Been Tested?

Verified locally that the component renders correctly without warnings when `min` and `max` props are not provided, confirming the default values are applied. Ensured the component still functions as expected when `min` and `max` *are* provided. Confirmed the `white` prop defaults to `false` correctly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.