### PR TITLE
Added QSpinner inside BGPMonitor.vue

### DIFF
--- a/src/views/BGPMonitor.vue
+++ b/src/views/BGPMonitor.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {
+  QSpinner,
   QBtn,
   QSelect,
   QInput,
@@ -1150,6 +1151,12 @@ onUnmounted(() => {
   <div class="IHR_char-container relative-position">
     <h1 class="text-center q-pa-xl">BGP Monitor</h1>
     <QCard>
+      <div
+        v-if="firstLoad || isLoadingBgplayData"
+        class="absolute-full flex flex-center bg-white bg-opacity-70 z-top"
+      >
+        <QSpinner size="40px" color="primary" />
+      </div>
       <QCardSection>
         <div class="row">
           <div class="col-2 q-mr-xl">


### PR DESCRIPTION
## Description

Added QSpinner inside BGPMonitor.vue
and added this code block 
```
<div
        v-if="firstLoad || isLoadingBgplayData"
        class="absolute-full flex flex-center bg-white bg-opacity-70 z-top"
      >
        <QSpinner size="40px" color="primary" />
      </div>
```

## Related issue

#1048 

## How Has This Been Tested?

Run the website with all the steps as provided and tested the loading wheel implementation

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
