### PR TITLE
Replace Plotly map with Leaflet in Disco view, add grayscale tile layer, and fix disco API endpoint

### DIFF
--- a/src/components/charts/DiscoChart.vue
+++ b/src/components/charts/DiscoChart.vue
@@ -85,11 +85,13 @@ const apiCall = () => {
     filters = new DiscoEventQuery()
       .streamName('')
       .timeInterval(props.startTime, props.endTime)
+      .includeProbeDetails('True')
       .orderedByTime()
   } else {
     filters = new DiscoEventQuery()
       .streamName(props.streamName)
       .timeInterval(props.startTime, props.endTime)
+      .includeProbeDetails('True')
       .orderedByTime()
   }
   loading.value = true

--- a/src/components/maps/DiscoMap.vue
+++ b/src/components/maps/DiscoMap.vue
@@ -1,9 +1,9 @@
 <script setup>
-import ReactiveChart from '../charts/ReactiveChart.vue'
-import { COMMON_FEATURE } from '@/plugins/layouts/layoutsChart.js'
 import getCountryName from '@/plugins/countryName'
 import { ref, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { LMap, LTileLayer, LCircleMarker, LTooltip } from '@vue-leaflet/vue-leaflet'
+import 'leaflet/dist/leaflet.css'
 
 const { t } = useI18n()
 
@@ -22,19 +22,9 @@ const props = defineProps({
   }
 })
 
-const layout = ref({
-  ...COMMON_FEATURE,
-  geo: {
-    showframe: false,
-    showcoastlines: false,
-    showland: true,
-    landcolor: 'rgb(215, 215, 215)',
-    countrycolor: 'rgb(235, 235, 235)',
-    showcountries: true
-  }
-})
 const probes = ref([])
 const noData = ref(t('loading'))
+const zoom = ref(2)
 
 const updateProbes = () => {
   probes.value = []
@@ -88,16 +78,9 @@ watch(
 )
 
 const traces = computed(() => {
-  let latitudes = []
-  let longitudes = []
-  let sizes = []
-  let colors = []
-  let text = []
-  probes.value.forEach((prob) => {
-    latitudes.push(prob.lat)
-    longitudes.push(prob.lon)
+  return probes.value.map((prob) => {
     let color = prob.level - 6
-    let durationHour = Math.ceil(Math.abs(prob.endTime - prob.startTime) / (1000 * 60 * 60))
+    const durationHour = Math.ceil(Math.abs(prob.endTime - prob.startTime) / (1000 * 60 * 60))
     let durationMin = Math.ceil(Math.abs(prob.endTime - prob.startTime) / (1000 * 60))
     let durationLabel = `${durationHour} hours`
     if (durationHour <= 1) {
@@ -106,49 +89,58 @@ const traces = computed(() => {
     if (durationMin == 0) {
       durationLabel = 'Unk.'
     }
-    let probeText = `<b>${prob.label}</b><br> PB${prob.id}<br> ${dateFormatter(
+    const probeText = `<b>${prob.label}</b><br> PB${prob.id}<br> ${dateFormatter(
       prob.startTime
     )}<br> Duration: ${durationLabel}<br> Deviation: ${prob.level}`
-    text.push(probeText)
     if (durationMin == 0) {
       durationMin = 30
     }
-    sizes.push(Math.min(durationMin / 2, 30))
+    const size = Math.min(durationMin / 2, 30)
     const red = Math.min(255, 255 * (color / 5))
     const green = 255 - Math.min(255, 255 * (color / 5))
     const blue = 255 - Math.min(255, 255 * (color / 5))
-    colors.push(`rgba(${red},${green},${blue},0.1)`)
-  })
-  return [
-    {
-      type: 'scattergeo',
-      mode: 'markers',
-      lat: latitudes,
-      lon: longitudes,
-      hoverinfo: 'text',
-      text: text,
-      marker: {
-        size: sizes,
-        color: colors,
-        line: {
-          color: 'black',
-          width: 1
-        }
-      },
-      name: 'world events'
+    color = `rgba(${red},${green},${blue},0.2)`
+    return {
+      lat: prob.lat,
+      lon: prob.lon,
+      text: probeText,
+      size: size,
+      color: color
     }
-  ]
+  })
 })
 </script>
 
 <template>
-  <div class="IHR_disco-chart">
-    <ReactiveChart
-      :layout="layout"
-      :traces="traces"
-      :no-data="noData"
-      :disableCVD="true"
-      :y-max="yMax"
-    />
+  <div style="height: 600px">
+    <LMap
+      v-model="zoom"
+      v-model:zoom="zoom"
+      :center="[0, 0]"
+      :use-global-leaflet="false"
+      :options="{ attributionControl: false }"
+    >
+      <LTileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        layer-type="base"
+        name="OpenStreetMap"
+        class="grayscale-tiles"
+      ></LTileLayer>
+      <LCircleMarker
+        v-for="trace in traces"
+        :lat-lng="[trace.lat, trace.lon]"
+        :radius="trace.size"
+        :color="trace.color"
+        :fillOpacity="1"
+      >
+        <LTooltip><div v-html="trace.text" style="text-align: left"></div></LTooltip>
+      </LCircleMarker>
+    </LMap>
   </div>
 </template>
+
+<style scoped>
+:deep(.leaflet-tile-pane) {
+  filter: grayscale(100%) brightness(1.1);
+}
+</style>

--- a/src/components/networks/country/CountryOverview.vue
+++ b/src/components/networks/country/CountryOverview.vue
@@ -311,6 +311,7 @@ onMounted(() => {
                 url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 layer-type="base"
                 name="OpenStreetMap"
+                class="grayscale-tiles"
               ></LTileLayer>
               <LControl>
                 <QCard>
@@ -378,7 +379,7 @@ onMounted(() => {
   </div>
 </template>
 
-<style>
+<style scoped>
 p {
   font-size: 1rem;
   margin-bottom: 0;
@@ -392,5 +393,8 @@ h3 {
   cursor: pointer;
   width: 100%;
   text-align: right;
+}
+:deep(.leaflet-tile-pane) {
+  filter: grayscale(100%) brightness(1.1);
 }
 </style>

--- a/src/plugins/query/IhrQuery.js
+++ b/src/plugins/query/IhrQuery.js
@@ -376,6 +376,10 @@ class DiscoEventQuery extends TimeQuery {
     return this._setOrder('nbdiscoprobes', order)
   }
 
+  includeProbeDetails(value) {
+    return this._set('include_probe_details', value)
+  }
+
   orderedByTime() {
     return this.orderedByStartTime()
   }


### PR DESCRIPTION
## Description

Replaced the Plotly-based map in the Disco view with an interactive Leaflet map. The new map uses leaflet components to display probe markers, which maintain a consistent pixel-based size regardless of zoom level. The tile layer is rendered in grayscale to improve the visibility of the colored probe overlays. Hovering over a marker shows a tooltip with probe details (label, probe ID, start time, duration, and deviation).

Additionally, the CountryOverview map tile layer has been updated to grayscale for visual consistency.

The disco/event API endpoint call has also been fixed following a recent API change.

## How Has This Been Tested?

Testing URLs:

- http://localhost:5173/en/network/AS8881?af=4&last=3&date=2024-04-02&active=monitoring
- http://localhost:5173/en/country/JP?af=4&last=3&date=2026-04-01&active=overview

## Screenshots (if appropriate):

<img width="3600" height="2092" alt="image" src="https://github.com/user-attachments/assets/b5b53501-b886-4d7e-94f2-600122fc590b" />

<img width="1773" height="935" alt="image" src="https://github.com/user-attachments/assets/5a173aa3-c80e-4882-93f5-0dffdc2bb188" />

<img width="3600" height="2092" alt="image" src="https://github.com/user-attachments/assets/db0fed40-7628-4176-b895-857b20b01373" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.